### PR TITLE
Fix a recipe conflict with croptopia, fix the mining dimension script, adds geore growth recipes

### DIFF
--- a/kubejs/server_scripts/modpack/mining_dim.js
+++ b/kubejs/server_scripts/modpack/mining_dim.js
@@ -401,7 +401,6 @@ ServerEvents.generateData("after_mods", (allthemods) => {
     endStoneReplaces,
     netherrackReplaces
   ) => {
-    if (!Item.exists(id)) return
     let jsonPlaced = JsonIO.toObject({
       feature: id,
       placement: [
@@ -440,11 +439,15 @@ ServerEvents.generateData("after_mods", (allthemods) => {
 
     let jsonForge = JsonIO.toObject({
       type: "neoforge:add_features",
-      biomes: "#allthemodium:mining_features/mining_biomes",
-      features: [id],
+      biomes: "allthemodium:mining",
+      features: id,
       step: "underground_ores"
     })
     if (stoneReplaces !== null) {
+      if (!Item.exists(stoneReplaces)) {
+        console.warn(`${stoneReplaces} does not exist`)
+        return
+      }
       jsonConfigured.config.targets.push(
         JsonIO.toObject({
           target: {
@@ -458,6 +461,10 @@ ServerEvents.generateData("after_mods", (allthemods) => {
       )
     }
     if (deepslateReplaces !== null) {
+      if (!Item.exists(deepslateReplaces)) {
+        console.warn(`${deepslateReplaces} does not exist`)
+        return
+      }
       jsonConfigured.config.targets.push(
         JsonIO.toObject({
           target: {
@@ -471,6 +478,10 @@ ServerEvents.generateData("after_mods", (allthemods) => {
       )
     }
     if (endStoneReplaces !== null) {
+      if (!Item.exists(endStoneReplaces)) {
+        console.warn(`${endStoneReplaces} does not exist`)
+        return
+      }
       jsonConfigured.config.targets.push(
         JsonIO.toObject({
           target: {
@@ -484,6 +495,10 @@ ServerEvents.generateData("after_mods", (allthemods) => {
       )
     }
     if (netherrackReplaces !== null) {
+      if (!Item.exists(netherrackReplaces)) {
+        console.warn(`${netherrackReplaces} does not exist`)
+        return
+      }
       jsonConfigured.config.targets.push(
         JsonIO.toObject({
           target: {

--- a/kubejs/server_scripts/mods/energizedpower/recipes.js
+++ b/kubejs/server_scripts/mods/energizedpower/recipes.js
@@ -1,0 +1,74 @@
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
+
+ServerEvents.recipes((allthemods) => {
+  /**
+   *
+   * @param {string} input
+   * @param {string} result
+   * @param {number[]} percentages
+   * @param {number} ticks
+   */
+  function crystal_growth_chamber(input, result, percentages, ticks) {
+    let recipe = {
+      type: "energizedpower:crystal_growth_chamber",
+      ingredient: {
+        ingredient: input
+      },
+      result: {
+        percentages: percentages,
+        result: {
+          id: result
+        }
+      },
+      ticks: ticks
+    }
+    allthemods.custom(recipe).id(`allthemods:energizedpower/crystal_growing/${result.split(":")[1]}`)
+  }
+
+  const COMMON = [1.0, 1.0, 0.67, 0.5, 0.25, 0.125]
+  const UNCOMMON = [1.0, 0.8, 0.5, 0.25, 0.1, 0.05]
+  const RARE = [1.0, 0.5, 0.25, 0.1, 0.05, 0.01]
+  const VERY_RARE = [1.0, 0.25, 0.1, 0.03, 0.01]
+
+  for (const [id, chances, ticks] of [
+    ["iron", COMMON, 12000],
+    ["gold", UNCOMMON, 18000],
+    ["copper", COMMON, 12000],
+    ["zinc", COMMON, 12000],
+    ["uranium", RARE, 28000],
+    ["tin", COMMON, 12000],
+    ["silver", UNCOMMON, 18000],
+    ["platinum", RARE, 32000],
+    ["osmium", UNCOMMON, 22000],
+    ["aluminum", COMMON, 12000],
+    ["lead", COMMON, 14000],
+    ["nickel", COMMON, 14000],
+    ["tungsten", RARE, 18000],
+
+    ["coal", COMMON, 10000],
+    ["diamond", RARE, 36000],
+    ["emerald", VERY_RARE, 48000],
+    ["lapis", COMMON, 14000],
+    ["quartz", COMMON, 12000],
+    ["redstone", COMMON, 14000],
+
+    ["ancient_debris", VERY_RARE, 64000],
+
+    ["sapphire", UNCOMMON, 18000],
+    ["ruby", UNCOMMON, 18000],
+    ["topaz", COMMON, 14000],
+    ["uraninite", RARE, 28000],
+    ["monazite", RARE, 28000],
+    ["black_quartz", COMMON, 12000],
+
+    ["allthemodium", VERY_RARE, 96000],
+    ["vibranium", VERY_RARE, 128000],
+    ["unobtainium", VERY_RARE, 160000]
+  ]) {
+    crystal_growth_chamber(`#geore:geore_shards/${id}`, `geore:${id}_shard`, chances, ticks)
+  }
+})
+
+// This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods.
+// As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -127,6 +127,20 @@ ServerEvents.recipes((allthemods) => {
         .id("allthemods:saltpeter_dust_from_block")
     }
   }
+
+  allthemods.remove({ id: "croptopia:knife" })
+  allthemods.shaped(
+    Item.of('croptopia:knife'),
+    [
+      ' I ',
+      ' I ',
+      'S  '
+    ],
+    {
+      S: '#c:rods/wooden',
+      I: '#c:ingots/iron',
+    }
+  ).id("croptopia:knife")
 })
 
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods.


### PR DESCRIPTION
- Adds `energizedpower:crystal_growth_chamber` recipes for all geore shards
   - Resolves #36 
   - Values may or may not need to be double checked? I picked stuff that seemed reasonable, but maybe someone disagrees
   
 - Fixes a recipe conflict between chisel and croptopia
    - Resolves #93
    - Resolves #143 
    - Changes the croptopia knife recipe from one stick and iron ingot to add a second iron ingot
   
- Fixes the mining dimension script to make all the modded ores spawn again
   - Resolves #64 
   - Resolves #143 
   - Resolves #157 
   - Spawn rates are left untouched and may need some tweaking