### PR TITLE
Update EP config: Upgrade values for v3.0.0-beta.1

### DIFF
--- a/config/energizedpower/client.conf
+++ b/config/energizedpower/client.conf
@@ -1,5 +1,10 @@
 # === Energized Power Client Config ===
 
+# The config version of this config file
+# [Default value]: 3.0.0-beta.1
+# [Validation]: This value should not be changed
+config_version = 3.0.0-beta.1
+
 # The tick amount to wait between two images in the Energized Power Book
 # [Default value]: 50
 # [Validation]: Value >= 5

--- a/config/energizedpower/common.conf
+++ b/config/energizedpower/common.conf
@@ -1,5 +1,10 @@
 # === Energized Power Common Config (IMPORTANT: Not all values are synced from the server to the client.) ===
 
+# The config version of this config file
+# [Default value]: 3.0.0-beta.1
+# [Validation]: This value should not be changed
+config_version = 3.0.0-beta.1
+
 # The energy capacity of the Battery (Tier I) in FE
 # [Default value]: 256
 # [Validation]: Value >= 1
@@ -201,6 +206,36 @@ item.speed_upgrade_module_5.effect_value = 6.000000
 # [Validation]: Value > 1.0
 item.speed_upgrade_module_5.effect_value.energy_consumption = 10.000000
 
+# The upgrade module effect (Production speed multiplier) of the Speed Upgrade Module (Tier VI)
+# [Default value]: 10.000000
+# [Validation]: Value > 1.0
+item.speed_upgrade_module_6.effect_value = 10.000000
+
+# The upgrade module effect (Energy Consumption per tick multiplier) of the Speed Upgrade Module (Tier VI)
+# [Default value]: 20.000000
+# [Validation]: Value > 1.0
+item.speed_upgrade_module_6.effect_value.energy_consumption = 20.000000
+
+# The upgrade module effect (Production speed multiplier) of the Speed Upgrade Module (Tier VII)
+# [Default value]: 20.000000
+# [Validation]: Value > 1.0
+item.speed_upgrade_module_7.effect_value = 20.000000
+
+# The upgrade module effect (Energy Consumption per tick multiplier) of the Speed Upgrade Module (Tier VII)
+# [Default value]: 40.000000
+# [Validation]: Value > 1.0
+item.speed_upgrade_module_7.effect_value.energy_consumption = 40.000000
+
+# The upgrade module effect (Production speed multiplier) of the Speed Upgrade Module (Tier VIII)
+# [Default value]: 40.000000
+# [Validation]: Value > 1.0
+item.speed_upgrade_module_8.effect_value = 40.000000
+
+# The upgrade module effect (Energy Consumption per tick multiplier) of the Speed Upgrade Module (Tier VIII)
+# [Default value]: 80.000000
+# [Validation]: Value > 1.0
+item.speed_upgrade_module_8.effect_value.energy_consumption = 80.000000
+
 # The upgrade module effect (Energy Consumption per tick multiplier) of the Energy Efficiency Upgrade Module (Tier I)
 # [Default value]: 0.900000
 # [Validation]: Value > 0.0
@@ -229,7 +264,65 @@ item.energy_efficiency_upgrade_module_4.effect_value = 0.400000
 # [Default value]: 0.200000
 # [Validation]: Value > 0.0
 # [Validation]: Value < 1.0
+item.energy_efficiency_upgrade_module_5.effect_value = 0.200000
+
+# The upgrade module effect (Energy Consumption per tick multiplier) of the Energy Efficiency Upgrade Module (Tier VI)
+# [Default value]: 0.100000
+# [Validation]: Value > 0.0
+# [Validation]: Value < 1.0
+item.energy_efficiency_upgrade_module_6.effect_value = 0.100000
+
+# The upgrade module effect (Energy Consumption per tick multiplier) of the Energy Efficiency Upgrade Module (Tier VII)
+# [Default value]: 0.050000
+# [Validation]: Value > 0.0
+# [Validation]: Value < 1.0
+item.energy_efficiency_upgrade_module_7.effect_value = 0.050000
+
+# The upgrade module effect (Energy Consumption per tick multiplier) of the Energy Efficiency Upgrade Module (Tier VIII)
+# [Default value]: 0.025000
+# [Validation]: Value > 0.0
+# [Validation]: Value < 1.0
 item.energy_efficiency_upgrade_module_8.effect_value = 0.200000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier I)
+# [Default value]: 1.050000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_1.effect_value = 1.050000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier II)
+# [Default value]: 1.150000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_2.effect_value = 1.150000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier III)
+# [Default value]: 1.250000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_3.effect_value = 1.250000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier IV)
+# [Default value]: 1.400000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_4.effect_value = 1.400000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier V)
+# [Default value]: 1.600000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_5.effect_value = 1.600000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier VI)
+# [Default value]: 1.800000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_6.effect_value = 1.800000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier VII)
+# [Default value]: 2.000000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_7.effect_value = 2.000000
+
+# The upgrade module effect (Energy Production per tick multiplier) of the Energy Production Upgrade Module (Tier VIII)
+# [Default value]: 2.500000
+# [Validation]: Value > 1.0
+item.energy_production_upgrade_module_8.effect_value = 2.500000
 
 # The upgrade module effect (Energy capacity multiplier) of the Energy Capacity Upgrade Module (Tier I)
 # [Default value]: 1.500000
@@ -281,6 +374,36 @@ item.energy_capacity_upgrade_module_5.effect_value = 10.000000
 # [Validation]: Value > 1.0
 item.energy_capacity_upgrade_module_5.energy_transfer_rate.effect_value = 10.000000
 
+# The upgrade module effect (Energy capacity multiplier) of the Energy Capacity Upgrade Module (Tier VI)
+# [Default value]: 20.000000
+# [Validation]: Value > 1.0
+item.energy_capacity_upgrade_module_6.effect_value = 20.000000
+
+# The upgrade module effect (Energy transfer rate multiplier) of the Energy Capacity Upgrade Module (Tier VI)
+# [Default value]: 20.000000
+# [Validation]: Value > 1.0
+item.energy_capacity_upgrade_module_6.energy_transfer_rate.effect_value = 20.000000
+
+# The upgrade module effect (Energy capacity multiplier) of the Energy Capacity Upgrade Module (Tier VII)
+# [Default value]: 40.000000
+# [Validation]: Value > 1.0
+item.energy_capacity_upgrade_module_7.effect_value = 40.000000
+
+# The upgrade module effect (Energy transfer rate multiplier) of the Energy Capacity Upgrade Module (Tier VII)
+# [Default value]: 40.000000
+# [Validation]: Value > 1.0
+item.energy_capacity_upgrade_module_7.energy_transfer_rate.effect_value = 40.000000
+
+# The upgrade module effect (Energy capacity multiplier) of the Energy Capacity Upgrade Module (Tier VIII)
+# [Default value]: 80.000000
+# [Validation]: Value > 1.0
+item.energy_capacity_upgrade_module_8.effect_value = 80.000000
+
+# The upgrade module effect (Energy transfer rate multiplier) of the Energy Capacity Upgrade Module (Tier VIII)
+# [Default value]: 80.000000
+# [Validation]: Value > 1.0
+item.energy_capacity_upgrade_module_8.energy_transfer_rate.effect_value = 80.000000
+
 # The upgrade module effect (Duration multiplier) of the Duration Upgrade Module (Tier I)
 # [Default value]: 4.000000
 # [Validation]: Value > 1.0
@@ -296,7 +419,7 @@ item.duration_upgrade_module_2.effect_value = 10.000000
 # [Validation]: Value > 1.0
 item.duration_upgrade_module_3.effect_value = 20.000000
 
-# The upgrade module effect (Duration multiplier) of the Duration Upgrade Module (Tier VI)
+# The upgrade module effect (Duration multiplier) of the Duration Upgrade Module (Tier IV)
 # [Default value]: 50.000000
 # [Validation]: Value > 1.0
 item.duration_upgrade_module_4.effect_value = 50.000000
@@ -356,6 +479,11 @@ item.extraction_depth_upgrade_module_4.effect_value = 128
 # [Validation]: Value >= 1
 item.extraction_depth_upgrade_module_5.effect_value = 192
 
+# The upgrade module effect (Addition Extraction Depth in Blocks) of the Extraction Depth Upgrade Module (Tier VI)
+# [Default value]: 320
+# [Validation]: Value >= 1
+item.extraction_depth_upgrade_module_6.effect_value = 320
+
 # The upgrade module effect (Range multiplier) of the Extraction Range Upgrade Module (Tier I)
 # [Default value]: 1.250000
 # [Validation]: Value > 1.0
@@ -381,6 +509,11 @@ item.extraction_range_upgrade_module_4.effect_value = 2.500000
 # [Validation]: Value > 1.0
 item.extraction_range_upgrade_module_5.effect_value = 3.000000
 
+# The upgrade module effect (Range multiplier) of the Extraction Range Upgrade Module (Tier VI)
+# [Default value]: 5.000000
+# [Validation]: Value > 1.0
+item.extraction_range_upgrade_module_6.effect_value = 5.000000
+
 # The upgrade module effect (Multiplier of peak energy production during nighttime relative to the peak energy production during daytime) of the Moon Light Upgrade Module (Tier I)
 # [Default value]: 0.125000
 # [Validation]: Value > 0.0
@@ -395,6 +528,76 @@ item.moon_light_upgrade_module_2.effect_value = 0.330000
 # [Default value]: 0.660000
 # [Validation]: Value > 0.0
 item.moon_light_upgrade_module_3.effect_value = 0.660000
+
+# The upgrade module effect (Multiplier of peak energy production during nighttime relative to the peak energy production during daytime) of the Moon Light Upgrade Module (Tier IV)
+# [Default value]: 0.850000
+# [Validation]: Value > 0.0
+item.moon_light_upgrade_module_4.effect_value = 0.850000
+
+# The upgrade module effect (Multiplier of peak energy production during nighttime relative to the peak energy production during daytime) of the Moon Light Upgrade Module (Tier V)
+# [Default value]: 1.000000
+# [Validation]: Value > 0.0
+item.moon_light_upgrade_module_5.effect_value = 1.000000
+
+# The upgrade module effect (Items per tick) of the Item Ejector Upgrade Module (Tier I)
+# [Default value]: 0.050000
+# [Validation]: Value > 0.0
+item.item_ejector_upgrade_module_1.effect_value = 0.050000
+
+# The upgrade module effect (Items per tick) of the Item Ejector Upgrade Module (Tier II)
+# [Default value]: 0.250000
+# [Validation]: Value > 0.0
+item.item_ejector_upgrade_module_2.effect_value = 0.250000
+
+# The upgrade module effect (Items per tick) of the Item Ejector Upgrade Module (Tier III)
+# [Default value]: 1.000000
+# [Validation]: Value > 0.0
+item.item_ejector_upgrade_module_3.effect_value = 1.000000
+
+# The upgrade module effect (Items per tick) of the Item Ejector Upgrade Module (Tier IV)
+# [Default value]: 4.000000
+# [Validation]: Value > 0.0
+item.item_ejector_upgrade_module_4.effect_value = 4.000000
+
+# The upgrade module effect (Items per tick) of the Item Ejector Upgrade Module (Tier V)
+# [Default value]: 8.000000
+# [Validation]: Value > 0.0
+item.item_ejector_upgrade_module_5.effect_value = 8.000000
+
+# The upgrade module effect (Items per tick) of the Item Ejector Upgrade Module (Tier VI)
+# [Default value]: 16.000000
+# [Validation]: Value > 0.0
+item.item_ejector_upgrade_module_6.effect_value = 16.000000
+
+# The upgrade module effect (Items per tick) of the Item Pulling Upgrade Module (Tier I)
+# [Default value]: 0.050000
+# [Validation]: Value > 0.0
+item.item_pulling_upgrade_module_1.effect_value = 0.050000
+
+# The upgrade module effect (Items per tick) of the Item Pulling Upgrade Module (Tier II)
+# [Default value]: 0.250000
+# [Validation]: Value > 0.0
+item.item_pulling_upgrade_module_2.effect_value = 0.250000
+
+# The upgrade module effect (Items per tick) of the Item Pulling Upgrade Module (Tier III)
+# [Default value]: 1.000000
+# [Validation]: Value > 0.0
+item.item_pulling_upgrade_module_3.effect_value = 1.000000
+
+# The upgrade module effect (Items per tick) of the Item Pulling Upgrade Module (Tier IV)
+# [Default value]: 4.000000
+# [Validation]: Value > 0.0
+item.item_pulling_upgrade_module_4.effect_value = 4.000000
+
+# The upgrade module effect (Items per tick) of the Item Pulling Upgrade Module (Tier V)
+# [Default value]: 8.000000
+# [Validation]: Value > 0.0
+item.item_pulling_upgrade_module_5.effect_value = 8.000000
+
+# The upgrade module effect (Items per tick) of the Item Pulling Upgrade Module (Tier VI)
+# [Default value]: 16.000000
+# [Validation]: Value > 0.0
+item.item_pulling_upgrade_module_6.effect_value = 16.000000
 
 # The energy capacity of the Battery Box in FE
 # [Default value]: 65536
@@ -491,6 +694,16 @@ block.weather_controller.transfer_rate = 32768
 # [Default value]: 19200
 # [Validation]: Value >= 100
 block.weather_controller.control_duration = 19200
+
+# The amount of time in ticks the Weather Controller will change the weather before setting it again if the Infinite Duration upgrade is installed.
+# [Default value]: 100
+# [Validation]: Value >= 100
+block.weather_controller.infinite_weather_reset_timeout = 100
+
+# The amount of time in ticks the Weather Controller will change the weather for if the Infinite Duration upgrade is installed.
+# [Default value]: 1200
+# [Validation]: Value >= 100
+block.weather_controller.infinite_weather_control_timeout = 1200
 
 # The energy capacity of the Lightning Generator in FE
 # [Default value]: 1000000
@@ -727,6 +940,21 @@ block.solar_panel_6.transfer_rate = 524288
 # [Default value]: 131072
 # [Validation]: Value >= 1
 block.solar_panel_6.energy_peak_production = 131072
+
+# The energy capacity of the Solar Panel (Tier VII) in FE
+# [Default value]: 4194304
+# [Validation]: Value >= 1
+block.solar_panel_7.capacity = 4194304
+
+# The energy transfer rate of the Solar Panel (Tier VII) in FE per tick
+# [Default value]: 2097152
+# [Validation]: Value >= 1
+block.solar_panel_7.transfer_rate = 2097152
+
+# The peak energy production of the Solar Panel (Tier VII) for ideal conditions (e.g. at noon with clear sky for solar panels) in FE per tick
+# [Default value]: 524288
+# [Validation]: Value >= 1
+block.solar_panel_7.energy_peak_production = 524288
 
 # The energy capacity of the Minecart Charger in FE
 # [Default value]: 16384
@@ -1137,12 +1365,10 @@ block.induction_smelter.transfer_rate = 256
 # [Validation]: Value >= 1
 block.induction_smelter.energy_consumption_per_tick = 64
 
-# The multiplier by which the time a recipe of the Induction Smelter requires is multiplied by.
-# => If set to 2 the Induction Smelter will be as fast as the Alloy Furnace.
-#
-# [Default value]: 1.000000
+# The multiplier by which the time a recipe of the Induction Smelter requires is multiplied by
+# [Default value]: 0.500000
 # [Validation]: Value > 0.0
-block.induction_smelter.recipe_duration_multiplier = 1.000000
+block.induction_smelter.recipe_duration_multiplier = 0.500000
 
 # The energy transfer rate of the Powered Lamp in FE per tick
 # [Default value]: 1
@@ -1164,12 +1390,10 @@ block.powered_furnace.transfer_rate = 128
 # [Validation]: Value >= 1
 block.powered_furnace.energy_consumption_per_tick = 2
 
-# The multiplier by which the time a recipe of the Powered Furnace requires is multiplied by.
-# => If set to 2 the Powered Furnace will be as fast as the normal Furnace.
-#
-# [Default value]: 1.000000
+# The multiplier by which the time a recipe of the Powered Furnace requires is multiplied by
+# [Default value]: 0.500000
 # [Validation]: Value > 0.0
-block.powered_furnace.recipe_duration_multiplier = 1.000000
+block.powered_furnace.recipe_duration_multiplier = 0.500000
 
 # The recipe blacklist for the Powered Furnace.
 # The blacklist is a list of recipe ids which can not be crafted in the Powered Furnace
@@ -1193,12 +1417,10 @@ block.advanced_powered_furnace.transfer_rate = 1024
 # [Validation]: Value >= 1
 block.advanced_powered_furnace.energy_consumption_per_input_per_tick = 256
 
-# The multiplier by which the time a recipe of the Advanced Powered Furnace requires is multiplied by.
-# => If set to 6 the Advanced Powered Furnace will be as fast as the normal Furnace.
-#
-# [Default value]: 1.000000
+# The multiplier by which the time a recipe of the Advanced Powered Furnace requires is multiplied by
+# [Default value]: 0.166667
 # [Validation]: Value > 0.0
-block.advanced_powered_furnace.recipe_duration_multiplier = 1.000000
+block.advanced_powered_furnace.recipe_duration_multiplier = 0.166667
 
 # The recipe blacklist for the Advanced Powered Furnace.
 # The blacklist is a list of recipe ids which can not be crafted in the Advanced Powered Furnace
@@ -1226,6 +1448,31 @@ block.plant_growth_chamber.energy_consumption_per_tick = 32
 # [Default value]: 1.000000
 # [Validation]: Value > 0.0
 block.plant_growth_chamber.recipe_duration_multiplier = 1.000000
+
+# The energy capacity of the Fluid Freezer in FE
+# [Default value]: 4096
+# [Validation]: Value >= 1
+block.fluid_freezer.capacity = 4096
+
+# The energy transfer rate of the Fluid Freezer in FE per tick
+# [Default value]: 256
+# [Validation]: Value >= 1
+block.fluid_freezer.transfer_rate = 256
+
+# The energy consumption of the Fluid Freezer if active in FE per tick
+# [Default value]: 128
+# [Validation]: Value >= 1
+block.fluid_freezer.energy_consumption_per_tick = 128
+
+# The fluid tank capacity of the Fluid Freezer in buckets (= 1000 mB)
+# [Default value]: 8
+# [Validation]: Value >= 1
+block.fluid_freezer.fluid_tank_capacity = 8
+
+# The time a recipe of the Fluid Freezer requires in ticks
+# [Default value]: 25
+# [Validation]: Value >= 1
+block.fluid_freezer.recipe_duration = 25
 
 # The energy capacity of the Stone Liquefier in FE
 # [Default value]: 4096
@@ -1472,15 +1719,30 @@ block.drain.fluid_tank_capacity = 2
 # [Validation]: Value >= 1
 block.drain.drain_duration = 20
 
-# The transfer rate per tank and face of an Iron Fluid Pipe face in the extraction state in mB (milli Buckets)
+# The transfer rate per tank and face of an Copper Fluid Pipe in the extraction state in mB (milli Buckets)
 # [Default value]: 100
 # [Validation]: Value >= 1
-block.iron_fluid_pipe.fluid_transfer_rate = 100
+block.copper_fluid_pipe.fluid_transfer_rate = 100
 
-# The transfer rate per tank and face of a Golden Fluid Pipe face in the extraction state in mB (milli Buckets)
+# The transfer rate per tank and face of an Iron Fluid Pipe in the extraction state in mB (milli Buckets)
+# [Default value]: 250
+# [Validation]: Value >= 1
+block.iron_fluid_pipe.fluid_transfer_rate = 250
+
+# The transfer rate per tank and face of an Golden Fluid Pipe in the extraction state in mB (milli Buckets)
 # [Default value]: 1000
 # [Validation]: Value >= 1
 block.golden_fluid_pipe.fluid_transfer_rate = 1000
+
+# The transfer rate per tank and face of an Steel Fluid Pipe in the extraction state in mB (milli Buckets)
+# [Default value]: 2500
+# [Validation]: Value >= 1
+block.steel_fluid_pipe.fluid_transfer_rate = 2500
+
+# The transfer rate per tank and face of an Pressurized Fluid Pipe in the extraction state in mB (milli Buckets)
+# [Default value]: 10000
+# [Validation]: Value >= 1
+block.pressurized_fluid_pipe.fluid_transfer_rate = 10000
 
 # The fluid tank capacity of the Fluid Tank (Small) in buckets (= 1000 mB)
 # [Default value]: 8
@@ -1691,14 +1953,17 @@ entity.advanced_battery_box_minecart.capacity = 8388608
 entity.advanced_battery_box_minecart.transfer_rate = 65536
 
 # Determines how frequent the Electrician Building 1 will be placed in villages.
-# => If set to 0 the Electrician Building 1 will never be placed.
+# => If set to 0 the electrician Building 1 will never be placed.
+# => Consider removing all references of the electrician house in the electrician book page if you completely remove the building:
+#    1. Remove the book page: https://wiki.jddev0.com/link/3#bkmrk-removal-of-the-elect
+#    2. Replace it with this version: https://wiki.jddev0.com/link/3#bkmrk-electrician-page-%28wi
 #
 # [Default value]: 5
 # [Validation]: Value >= 0
 # [Validation]: Value <= 100
 world.village.electrician_building_1.placement_weight = 0
 
-# Sets the timeout a machine needs to be off for to change the block state to off in ticks (Prevent light flickering)
+# Sets the timeout a machine needs to be off for to change the block state to off in ticks (Prevents light flickering)
 # [Default value]: 20
 # [Validation]: Value >= 5
 # [Validation]: Value <= 200

--- a/config/energizedpower/server.conf
+++ b/config/energizedpower/server.conf
@@ -1,1 +1,6 @@
 # === Energized Power Server Config ===
+
+# The config version of this config file
+# [Default value]: 3.0.0-beta.1
+# [Validation]: This value should not be changed
+config_version = 3.0.0-beta.1


### PR DESCRIPTION
There are some changes to the default config values since EP version 3.0.0-beta.1

This pull request adds the new config options since 3.0.0-beta.1 and upgrades the following config values:
- `block.induction_smelter.recipe_duration_multiplier`: Now `0.5` and no longer `1.0` (=> 2x times faster as alloy furnace)
- `block.powered_furnace.recipe_duration_multiplier`:  Now `0.5` and no longer `1.0` (=> 2x times faster as normal furnace)
- `block.advanced_powered_furnace.recipe_duration_multiplier`:  Now `0.166667` and no longer `1.0` (=> 6x times faster as normal furnace)
- `block.iron_fluid_pipe.fluid_transfer_rate`: Now `250` and no longer `100`, because the Copper pipe was added and it has `100`