### PR TITLE
fix(ma): invalid blockstate crash

### DIFF
--- a/kubejs/assets/mysticalagriculture/blockstates/allthemodium_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/allthemodium_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/allthemodium_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/azure_silver_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/azure_silver_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/azure_silver_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/black_quartz_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/black_quartz_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/black_quartz_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/crimson_iron_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/crimson_iron_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/crimson_iron_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/darkstone_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/darkstone_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/darkstone_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/entro_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/entro_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/entro_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/kivi_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/kivi_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/kivi_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/sky_steel_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/sky_steel_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/sky_steel_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/unexplored_wood_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/unexplored_wood_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/unexplored_wood_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/unobtainium_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/unobtainium_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/unobtainium_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/vibranium_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/vibranium_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/vibranium_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/blockstates/xychorium_gem_crop.json
+++ b/kubejs/assets/mysticalagriculture/blockstates/xychorium_gem_crop.json
@@ -1,0 +1,28 @@
+{
+  "variants": {
+    "age=0": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_0"
+    },
+    "age=1": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_1"
+    },
+    "age=2": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_2"
+    },
+    "age=3": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_3"
+    },
+    "age=4": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_4"
+    },
+    "age=5": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_5"
+    },
+    "age=6": {
+      "model": "mysticalagriculture:block/mystical_resource_crop_6"
+    },
+    "age=7": {
+      "model": "mysticalagriculture:block/xychorium_gem_crop"
+    }
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/allthemodium_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/allthemodium_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/azure_silver_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/azure_silver_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/black_quartz_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/black_quartz_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_rock"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/crimson_iron_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/crimson_iron_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/darkstone_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/darkstone_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/entro_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/entro_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/entro_flower"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/kivi_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/kivi_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/sky_steel_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/sky_steel_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/unexplored_wood_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/unexplored_wood_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_dust"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/unobtainium_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/unobtainium_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/vibranium_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/vibranium_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/flower_ingot"
+  }
+}

--- a/kubejs/assets/mysticalagriculture/models/block/xychorium_gem_crop.json
+++ b/kubejs/assets/mysticalagriculture/models/block/xychorium_gem_crop.json
@@ -1,0 +1,6 @@
+{
+  "parent": "mysticalagriculture:block/mystical_resource_crop_7",
+  "textures": {
+    "flower": "mysticalagriculture:block/xychorium_gem_flower"
+  }
+}


### PR DESCRIPTION
## Problem

See issue #196, when holding seeds in hand the game crashes with invalid block state errors, this only occurs on the client server works as normal.

## Solutions

First attempted to script the blockstate creation instead of manually creating the assets seen in this PR, however was unable to get that working. Instead opted to keep the manually created files as for now that appears to resolve the issue, and share my findings.

Currently unsure if there's a better approach to resolving this :thinking: