### PR TITLE
Recipe Changes (plus loot category override)

### DIFF
--- a/kubejs/dynamic_data/apotheosis/data_maps/item/loot_category_overrides.json
+++ b/kubejs/dynamic_data/apotheosis/data_maps/item/loot_category_overrides.json
@@ -3,6 +3,7 @@
         "allthemodium:alloy_paxel": "apotheosis:breaker",
         "silentgear:mace": "apotheosis:melee_weapon",
 		"silentgear:axe": "apotheosis:melee_weapon",
+		"silentgear:spear": "apotheosis:melee_weapon",
 		"oritech:promethium_pickaxe": "apotheosis:breaker",
 		"oritech:hand_drill": "apotheosis:breaker",
 		"draconicevolution:draconic_staff": "apotheosis:melee_weapon",

--- a/kubejs/server_scripts/mods/ae2/recipes.js
+++ b/kubejs/server_scripts/mods/ae2/recipes.js
@@ -25,6 +25,18 @@ if (Platform.isLoaded("ae2")) {
         })
         .id("allthemods:universal_press")
     }
+	else {
+	  allthemods
+        .shaped("kubejs:universal_press", ["FPF", "CSL", "FEF"], {
+          F: "#c:ingots/steel",
+          P: "ae2:silicon_press",
+          C: "ae2:calculation_processor_press",
+          S: "minecraft:slime_ball",
+          L: "ae2:logic_processor_press",
+          E: "ae2:engineering_processor_press"
+        })
+        .id("allthemods:universal_press")
+	}
 
     function universalPress(input, output, id) {
       allthemods
@@ -114,7 +126,7 @@ if (Platform.isLoaded("ae2")) {
       )
     }
 
-    if (Platform.isLoaded("applflux")) {
+    if (Platform.isLoaded("appflux")) {
       universalPress("appflux:charged_redstone", "appflux:printed_energy_processor", "printed_energy_processor")
     }
 

--- a/kubejs/server_scripts/mods/allthemodium/recipes.js
+++ b/kubejs/server_scripts/mods/allthemodium/recipes.js
@@ -2,30 +2,27 @@
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 
 ServerEvents.recipes((allthemods) => {
-  allthemods
-    .shapeless("9x allthemodium:piglich_heart", ["allthemodium:piglich_heart_block"])
-    .id("allthemods:allthemodium/heart_decompression")
   if (Item.exists("kubejs:silent_allthemodium_plate")) {
     allthemods.smithing(
       Item.of("kubejs:silent_allthemodium_plate"),
+	  "allthemodium:allthemodium_upgrade_smithing_template",
       "#c:plates/allthemodium",
-      "allthemodium:allthemodium_upgrade_smithing_template",
       "#c:ingots/netherite"
     )
   }
   if (Item.exists("kubejs:silent_vibranium_plate")) {
     allthemods.smithing(
       Item.of("kubejs:silent_vibranium_plate"),
-      "#c:plates/vibranium",
       "allthemodium:vibranium_upgrade_smithing_template",
+      "#c:plates/vibranium",
       "#c:ingots/allthemodium"
     )
   }
   if (Item.exists("kubejs:silent_unobtainium_plate")) {
     allthemods.smithing(
       Item.of("kubejs:silent_unobtainium_plate"),
-      "#c:plates/unobtainium",
       "allthemodium:unobtainium_upgrade_smithing_template",
+      "#c:plates/unobtainium",
       "#c:ingots/vibranium"
     )
   }

--- a/kubejs/server_scripts/mods/minecraft/recipes.js
+++ b/kubejs/server_scripts/mods/minecraft/recipes.js
@@ -1,7 +1,7 @@
 // This File has been authored by AllTheMods Staff, or a Community contributor for use in AllTheMods.
 // As all AllTheMods packs are licensed under All Rights Reserved, this file is not allowed to be used in any public packs not released by the AllTheMods Team, without explicit permission.
 ServerEvents.recipes((allthemods) => {
-  allthemods.remove({ id: "minecraft:cake" })
+  // allthemods.remove({ id: "minecraft:cake" })
 
   allthemods.shaped(
     Item.of("minecraft:sculk", 1), // arg 1: output

--- a/kubejs/server_scripts/tweaks/recipes.js
+++ b/kubejs/server_scripts/tweaks/recipes.js
@@ -113,15 +113,15 @@ ServerEvents.recipes((allthemods) => {
     ])
     .id("allthemods:example_firework_star")
   // Saltpeter Block Recipes
-  if (Item.exists("kubejs:saltpeter_block") && Platform.isLoaded("railcraft")) {
+  if (Item.exists("kubejs:saltpeter_block")) {
     allthemods
       .shaped(Item.of(`kubejs:saltpeter_block`), ["CCC", "CCC", "CCC"], {
         C: `#c:dusts/saltpeter`
       })
       .id("allthemods:saltpeter_block")
-    if (Platform.isLoaded("railcraft")) {
+    if (Platform.isLoaded("neovitae")) {
       allthemods
-        .shapeless(Item.of("railcraft:saltpeter_dust", 9), ["kubejs:saltpeter_block"])
+        .shapeless(Item.of("neovitae:saltpeter", 9), ["kubejs:saltpeter_block"])
         .id("allthemods:saltpeter_dust_from_block")
     }
   }


### PR DESCRIPTION
- Added Alternative Universal Press recipe if MEGA Cells is not installed (I decided on Steel instead of Sky Steel as a substitute) (fixes #193)
- Fixed AppliedFlux Universal Press condition
- Adjusted Silent ATM Metal Plate recipe (Smithing Templates now go where they should)
- Removed redundant Piglich Heart Decompression recipe (it's covered by Allthemodium now)
- Adjusted Saltpeter Block related recipes to depend on Neo Vitae instead of Railcraft
- Re-implemented vanilla Cake recipe
- Silent Gear Spears are now considered melee weapons for Apotheosis affixing purposes