### PR TITLE
Clear allowed mods for Infusion Pylon

### DIFF
--- a/config/pylons-server.toml
+++ b/config/pylons-server.toml
@@ -42,7 +42,7 @@
 	#Effects that may be used in the Infusion Pylon.
 	#List may include either effect IDs (like `minecraft:strength`) or an entire namespace (like `minecraft`).
 	#If the list is empty, then all effects will be allowed except for those specifically denied.
-	infusionAllowedEffects = ["minecraft"]
+	infusionAllowedEffects = []
 	#Effects that may not be used in the Infusion Pylon.
 	#This list will override the allowed effect list.
 	#Effects may also be added to the pylons:infusion_banned tag.


### PR DESCRIPTION
Changed allowed effects for the Infusion Pylon to an empty list to allow other mod potion effects. Same as in ATM10

with "minecraft" as the only allowed mod, potions such as the potion of flying cannot be absorbed.