### PR TITLE
A few KubeJS fixes

### DIFF
--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -5,7 +5,7 @@ ItemEvents.modifyTooltips((allthemods) => {
   // AllTheModium
 
   allthemods.add(
-    ["allthemodium:allthemodium_ore"],
+    ["allthemodium:allthemodium_ore", "allthemodium:deepslate_allthemodium_ore"],
     [
       Text.of("§7Needs at least Netherite to be mined"),
       Text.of("§6Found in the Deep Dark Biome and will always spawn air exposed"),

--- a/kubejs/server_scripts/mods/dyenamics/recipes.js
+++ b/kubejs/server_scripts/mods/dyenamics/recipes.js
@@ -24,22 +24,25 @@ if (Platform.isLoaded("dyenamics")) {
     ]
     dyenamicdyes.forEach((name) => {
       let material = `dyenamics:${name}_dye`
-
-      allthemods
-        .shapeless(Item.of(material, 3), [`occultism:otherflower`, material])
-        .id(`allthemods:crafting/otherflower_to_${name}_dye`)
-      allthemods.recipes.modern_industrialization
-        .mixer(2, 200)
-        .itemIn(material, 0)
-        .fluidIn(`25x modern_industrialization:benzene`)
-        .itemOut(material)
-        .id(`allthemods:modern_industrialization/dyes/${name}/mixer/benzene`)
-      allthemods.recipes.modern_industrialization
-        .mixer(2, 200)
-        .itemIn(material, 0)
-        .fluidIn(`100x modern_industrialization:synthetic_oil`)
-        .itemOut(material)
-        .id(`allthemods:modern_industrialization/dyes/${name}/mixer/synthetic_oil`)
+	  if (Platform.isLoaded("occultism")) {
+		  allthemods
+			.shapeless(Item.of(material, 4), [`occultism:otherflower`, material])
+			.id(`allthemods:crafting/otherflower_to_${name}_dye`)
+	  }
+	  if (Platform.isLoaded("modern_industrialization")) {
+		  allthemods.recipes.modern_industrialization
+			.mixer(2, 200)
+			.itemIn(material, 0)
+			.fluidIn(`25x modern_industrialization:benzene`)
+			.itemOut(material)
+			.id(`allthemods:modern_industrialization/dyes/${name}/mixer/benzene`)
+		  allthemods.recipes.modern_industrialization
+			.mixer(2, 200)
+			.itemIn(material, 0)
+			.fluidIn(`100x modern_industrialization:synthetic_oil`)
+			.itemOut(material)
+			.id(`allthemods:modern_industrialization/dyes/${name}/mixer/synthetic_oil`)
+	  }
     })
   })
 }


### PR DESCRIPTION
- Updated Dyenamics dye duplication recipes' condition (to potentially avoid issues when Dyenamics is installed but Modern Industrialization is not)
- Buffed Dyenamics Otherflower dye duplication to give 1 extra dye (to match Otherflower dye duplication with vanilla dyes)
- Adjusted Allthemodium Ore tooltip to work on Deepslate Allthemodium Ore as well