### PR TITLE
Add Agritech Planter compatibility for Mystical Customization seeds & Entro Seeds craft

### DIFF
--- a/kubejs/server_scripts/mods/mysticalagriculture/mysticalcustomization_agritech.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/mysticalcustomization_agritech.js
@@ -1,4 +1,4 @@
-if (Platform.isLoaded("mysticalagriculture")) {
+if (Platform.isLoaded("mysticalagriculture") && Platform.isLoaded("agritechevolved")) {
 
     ServerEvents.recipes(event => {
         

--- a/kubejs/server_scripts/mods/mysticalagriculture/mysticalcustomization_agritech.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/mysticalcustomization_agritech.js
@@ -1,0 +1,92 @@
+if (Platform.isLoaded("mysticalagriculture")) {
+
+    ServerEvents.recipes(event => {
+        
+        // List of crops to add with tier
+        const customCrops = [
+            { name: "kivi", tier: "2" },
+            { name: "unexplored_wood", tier: "2" },
+            { name: "azure_silver", tier: "3" },
+            { name: "black_quartz", tier: "3" },
+            { name: "crimson_iron", tier: "3" },
+            { name: "darkstone", tier: "3" },
+            { name: "xychorium_gem", tier: "3" },
+            { name: "entro", tier: "5" },
+            { name: "sky_steel", tier: "5" }
+        ];
+
+        // Adding Agritech Planter compatibility with Mystical Customization crops
+        customCrops.forEach(crop => {
+            
+            event.custom({
+                "type": "agritechevolved:crop",
+                "seed": `mysticalagriculture:${crop.name}_seeds`,
+                "soils": [
+                    `#agritechevolved:ma_tier${crop.tier}_soils`
+                ],
+                "drops": [
+                    {
+                        "item": `mysticalagriculture:${crop.name}_essence`,
+                        "min": 1,
+                        "max": 1,
+                        "chance": 1.0
+                    },
+                    {
+                        "item": `mysticalagriculture:${crop.name}_seeds`,
+                        "min": 1,
+                        "max": 1,
+                        "chance": 0.2
+                    },
+                    {
+                        "item": "mysticalagriculture:fertilized_essence",
+                        "min": 1,
+                        "max": 1,
+                        "chance": 0.1
+                    }
+                ]
+            });
+            
+        });
+
+        // List of magical crops to add
+        const customCropsMagical = [
+            { name: "allthemodium" },
+            { name: "vibranium" },
+            { name: "unobtainium" }
+        ];
+        
+        // Adding Agritech Planter compatibility with Mystical Customization magical crops
+        customCropsMagical.forEach(crop => {
+            
+            event.custom({
+                "type": "agritechevolved:crop",
+                "seed": `mysticalagriculture:${crop.name}_seeds`,
+                "soils": [
+                    `kubejs:magical_soil`
+                ],
+                "drops": [
+                    {
+                        "item": `mysticalagriculture:${crop.name}_essence`,
+                        "min": 1,
+                        "max": 1,
+                        "chance": 1.0
+                    },
+                    {
+                        "item": `mysticalagriculture:${crop.name}_seeds`,
+                        "min": 1,
+                        "max": 1,
+                        "chance": 0.2
+                    },
+                    {
+                        "item": "mysticalagriculture:fertilized_essence",
+                        "min": 1,
+                        "max": 1,
+                        "chance": 0.1
+                    }
+                ]
+            });
+            
+        });
+    });
+
+}

--- a/kubejs/server_scripts/mods/mysticalagriculture/mysticalcustomization_agritech.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/mysticalcustomization_agritech.js
@@ -2,17 +2,20 @@ if (Platform.isLoaded("mysticalagriculture") && Platform.isLoaded("agritechevolv
 
     ServerEvents.recipes(event => {
         
-        // List of crops to add with tier
+        // List of crops to add with their soil
         const customCrops = [
-            { name: "kivi", tier: "2" },
-            { name: "unexplored_wood", tier: "2" },
-            { name: "azure_silver", tier: "3" },
-            { name: "black_quartz", tier: "3" },
-            { name: "crimson_iron", tier: "3" },
-            { name: "darkstone", tier: "3" },
-            { name: "xychorium_gem", tier: "3" },
-            { name: "entro", tier: "5" },
-            { name: "sky_steel", tier: "5" }
+            { name: "kivi", soil: "#agritechevolved:ma_tier2_soils" },
+            { name: "unexplored_wood", soil: "#agritechevolved:ma_tier2_soils" },
+            { name: "azure_silver", soil: "#agritechevolved:ma_tier3_soils" },
+            { name: "black_quartz", soil: "#agritechevolved:ma_tier3_soils" },
+            { name: "crimson_iron", soil: "#agritechevolved:ma_tier3_soils" },
+            { name: "darkstone", soil: "#agritechevolved:ma_tier3_soils" },
+            { name: "xychorium_gem", soil: "#agritechevolved:ma_tier3_soils" },
+            { name: "entro", soil: "#agritechevolved:ma_tier5_soils" },
+            { name: "sky_steel", soil: "#agritechevolved:ma_tier5_soils" },
+            { name: "allthemodium", soil: "kubejs:magical_soil" },
+            { name: "vibranium", soil: "kubejs:magical_soil" },
+            { name: "unobtainium", soil: "kubejs:magical_soil" }
         ];
 
         // Adding Agritech Planter compatibility with Mystical Customization crops
@@ -22,7 +25,7 @@ if (Platform.isLoaded("mysticalagriculture") && Platform.isLoaded("agritechevolv
                 "type": "agritechevolved:crop",
                 "seed": `mysticalagriculture:${crop.name}_seeds`,
                 "soils": [
-                    `#agritechevolved:ma_tier${crop.tier}_soils`
+                    crop.soil
                 ],
                 "drops": [
                     {
@@ -48,45 +51,6 @@ if (Platform.isLoaded("mysticalagriculture") && Platform.isLoaded("agritechevolv
             
         });
 
-        // List of magical crops to add
-        const customCropsMagical = [
-            { name: "allthemodium" },
-            { name: "vibranium" },
-            { name: "unobtainium" }
-        ];
-        
-        // Adding Agritech Planter compatibility with Mystical Customization magical crops
-        customCropsMagical.forEach(crop => {
-            
-            event.custom({
-                "type": "agritechevolved:crop",
-                "seed": `mysticalagriculture:${crop.name}_seeds`,
-                "soils": [
-                    `kubejs:magical_soil`
-                ],
-                "drops": [
-                    {
-                        "item": `mysticalagriculture:${crop.name}_essence`,
-                        "min": 1,
-                        "max": 1,
-                        "chance": 1.0
-                    },
-                    {
-                        "item": `mysticalagriculture:${crop.name}_seeds`,
-                        "min": 1,
-                        "max": 1,
-                        "chance": 0.2
-                    },
-                    {
-                        "item": "mysticalagriculture:fertilized_essence",
-                        "min": 1,
-                        "max": 1,
-                        "chance": 0.1
-                    }
-                ]
-            });
-            
-        });
     });
 
 }

--- a/kubejs/server_scripts/mods/mysticalagriculture/recipes.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/recipes.js
@@ -284,7 +284,9 @@ if (Platform.isLoaded("mysticalagriculture")) {
 
     addInfustion('mysticalagriculture:silicon_seeds', 'ae2:silicon', 'mysticalagriculture:prudentium_essence')
     addInfustion('mysticalagriculture:steel_seeds', 'alltheores:steel_ingot', 'mysticalagriculture:imperium_essence')
-    addInfustion('mysticalagriculture:entro_seeds', 'extendedae:entro_crystal', 'mysticalagriculture:supremium_essence')
+    if (Platform.isLoaded("extendedae")) {
+      addInfustion('mysticalagriculture:entro_seeds', 'extendedae:entro_crystal', 'mysticalagriculture:supremium_essence')
+    }
 
     allthemods.custom({
       type: "mysticalagriculture:soul_extraction",

--- a/kubejs/server_scripts/mods/mysticalagriculture/recipes.js
+++ b/kubejs/server_scripts/mods/mysticalagriculture/recipes.js
@@ -284,6 +284,7 @@ if (Platform.isLoaded("mysticalagriculture")) {
 
     addInfustion('mysticalagriculture:silicon_seeds', 'ae2:silicon', 'mysticalagriculture:prudentium_essence')
     addInfustion('mysticalagriculture:steel_seeds', 'alltheores:steel_ingot', 'mysticalagriculture:imperium_essence')
+    addInfustion('mysticalagriculture:entro_seeds', 'extendedae:entro_crystal', 'mysticalagriculture:supremium_essence')
 
     allthemods.custom({
       type: "mysticalagriculture:soul_extraction",


### PR DESCRIPTION
Seeds added by Mystical Customization now work in Agritech Planter :
- AllTheModium
- Vibranium
- Unobtainium
- Azure Silver
- Black Quartz
- Crimson Iron
- Darkstone
- Entro
- Kivi
- Sky Steel
- Unexplored Woods
- Xychorium