### PR TITLE
Meteorite Divination Rod Recipe

### DIFF
--- a/kubejs/server_scripts/mods/ae2/recipes.js
+++ b/kubejs/server_scripts/mods/ae2/recipes.js
@@ -209,6 +209,22 @@ if (Platform.isLoaded("ae2")) {
       })
       .id("extendedae:slicing/universal_press")
     }
+	
+	// Meteorite Divination Rod recipe, to serve as the Ars Dowsing Rod's spiritual successor for finding meteorites
+	if (Platform.isLoaded("occultism")) {
+		allthemods
+			.custom({
+				"type": "ae2:charger",
+				"ingredient": "occultism:divination_rod",
+				"result": {
+					"components": {
+						"occultism:divination_linked_block": "ae2:mysterious_cube",
+						"custom_name": "Meteorite Divination Rod"
+					},
+					"id": "occultism:divination_rod"
+				}
+		}).id("allthemods:ae2/charger/meteorite_divination_rod")
+	}
   })
 }
 


### PR DESCRIPTION
A special version of the Divination Rod, attuned by default to a Mysterious Cube, to serve as the Ars Dowsing Rod's spiritual (pun not intended) successor in pinning down the precise location of a Meteorite once players used the Meteorite Compass to find its general location.