### PR TITLE
Follow-up quest changes to Toshiba's PR

### DIFF
--- a/config/ftbquests/quests/chapters/achapter_1_the_beginning.json5
+++ b/config/ftbquests/quests/chapters/achapter_1_the_beginning.json5
@@ -634,7 +634,6 @@
       shape: "octagon",
       dependencies: [
         "2063337BB2DEAB00",
-        "5159B6673D6D5ACE",
       ],
       size: 1.2,
       id: "34A822487EEF2A2A",
@@ -673,6 +672,9 @@
       x: 0.0,
       y: 17.5,
       shape: "gear",
+      dependencies: [
+        "34A822487EEF2A2A",
+      ],
       size: 1.5,
       id: "5159B6673D6D5ACE",
       tasks: [

--- a/config/ftbquests/quests/lang/en_us/chapters/achapter_1_the_beginning.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/achapter_1_the_beginning.json5
@@ -40,7 +40,7 @@
   ],
   "task.11C8CBF9FFFDA374.title": "Furnace Generators",
   "quest.2D01012FE7F9BA61.quest_desc": [
-    "These &dMagic Mods&r bring a focus to a unique way of Farming Items. \\n\\n&4&lNeo Vitae&r is a Ritual Mod that uses EV (basically &4Blood&r) as a price. It gives new Items, Potions and Charms, and even a whole Dimension to explore! There isn't a Quest for it. \\n\\n&b&lOccultism&r uses Rituals to summon Demons to do our bidding. Most require getting into the Occult by finding and Crafting Items we need to make Books to Bind to Demons. There is a Questline for &b&lOccultism&r! \\n\\n&6&lTheurgy&r is an overlooked Farming Mod. It breaks down Items into Salts, Mercuries, and Sulfurs and uses different Machines to Build them back up. Either into new Items, or more of the old one! Yes, there's a Quest for it too!",
+    "These &dMagic Mods&r bring a focus to a unique way of Farming Items. \\n\\n&4&lNeo Vitae&r is a Ritual Mod that uses EV (basically &4Blood&r) as a price. It gives new Items, Potions and Charms, and even a whole Dimension to explore! There isn't a Quest for it yet. \\n\\n&b&lOccultism&r uses Rituals to summon Demons to do our bidding. Most require getting into the Occult by finding and Crafting Items we need to make Books to Bind to Demons. There is a Questline for &b&lOccultism&r! \\n\\n&6&lTheurgy&r is an overlooked Farming Mod. It breaks down Items into Salts, Mercuries, and Sulfurs and uses different Machines to Build them back up. Either into new Items, or more of the old one! Yes, there's a Quest for it too!",
   ],
   "quest.6EB05138B989CAD9.title": "Straight to the &lIron Age",
   "quest.2063337BB2DEAB00.quest_desc": [
@@ -51,7 +51,7 @@
   ],
   "quest.291CE1BF9B5AE191.title": "&2&lFarming",
   "quest.3B61DE4CB34F6BC9.quest_desc": [
-    "Rarely any in &c&lThe Nether&r you can find &cAncient Debris&r. \\n\\nThese can only be Mined with a &bDiamond Pickaxe&r or better. Spoiler alert, there's better than &bDiamond&r. \\n\\nOnce Broken they'll Drop &cAncient Debris&r which can be Smelt into &cAncient Scraps&r. \\n\\nYou'll have to combine 4 &cAncient Scraps&r with 4 &eGold Ingots&r to make 1 &cNetherite Ingot&r.",
+    "Rarely any in &c&lThe Nether&r you can find &cAncient Debris&r. \\n\\nThese can only be Mined with a &bDiamond Pickaxe&r or better. Spoiler alert, there's better than &bDiamond&r. \\n\\nOnce Broken they'll Drop &cAncient Debris&r which can be Smelted into &cNetherite Scraps&r. \\n\\nYou'll have to combine 4 &cNetherite Scraps&r with 4 &eGold Ingots&r to make 1 &cNetherite Ingot&r.",
   ],
   "quest.616352EBF422192F.quest_desc": [
     "&6Backpacks&r give us an even greater way of Storing Items on the run. \\n\\n&6Backpacks&r have more Space, can be worn on your Back, and can be Opened normally. They can even be placed down like a &6Chest&r by Shift Right Clicking with them. \\n\\nThat's not even everything yet, they can also be upgraded to hold more Items, hold Liquids, or even play music like &5Jukeboxes&r!",
@@ -126,10 +126,10 @@
     "Don't worry, not every &2Farming Mod&r is as terrifying and complex as &2&lMystical Agriculture&r or &6&lProductive Bees&r. \\n\\nWe have a lot of simple ones that just add more Fruit, Veggies, ETC. to Farm and Eat. Like &d&lCroptopia&r and &a&lProductive Farming&r. \\n\\nThere's also a few Mods to help make making Food easier like &c&lCooking for Blockheads&r. \\n\\nDon't forget, this is your Instance of &6&lATM11&r, no one can tell you how to play. If you want to ignore the &6&lATM Star&r and just &2Farm&r then you do it! ",
   ],
   "quest.6CA3111E5B9FE80B.quest_desc": [
-    "&5&lApotheosis&r must hate lots of &2&lVanilla&r Mechanics because they change and add a ton! \\n\\nNow with 1.26 both &5&lApotheosis&r Adventure Module and Enchanting Module work hand in hand. \\n\\nThe Adventure Module focuses on upgrading Gears using &6Affixes&r and Gems. The Enchanting Module gives us different &6Bookshelves&r and Blocks to change the Levels of &5Enchantment Tables&r individually. \\n\\nNow the World Tiers from the Adventure Module also gates some &6Shelves&r and Blocks in the Enchanting Module.",
+    "&5&lApotheosis&r must hate lots of &2&lVanilla&r Mechanics because they change and add a ton! \\n\\nNow with 26.1 both &5&lApotheosis&r Adventure Module and Enchanting Module work hand in hand. \\n\\nThe Adventure Module focuses on upgrading Gears using &6Affixes&r and Gems. The Enchanting Module gives us different &6Bookshelves&r and Blocks to change the Levels of &5Enchantment Tables&r individually. \\n\\nNow the World Tiers from the Adventure Module also gates some &6Shelves&r and Blocks in the Enchanting Module.",
   ],
   "quest.271F9053B9EFAAEF.quest_desc": [
-    "&bTech &fand &bMachine Mods&r are a big selling point of Kitchen Sink Packs... but not many are updated right now. \\n\\nRight now we have &c&lEnergized Power&r, &3&lJust Dire Things&r, and &a&lEnderIO&r. \\n\\n&c&lEnergized Power&r and &a&lEnderIO&r are both very usual Tech Mods. Get &cEnergy&r, make Machines, use Machines. Neither of these have Quests. \\n\\n&3&lJust Dire Things&r is unique as it uses Goo. Goo converts Blocks into Crystals, and Crystals can be made into Machines and Tools. Thankfully this one does have a Quest.",
+    "&bTech &fand &bMachine Mods&r are a big selling point of Kitchen Sink Packs... but not many are updated right now. \\n\\nRight now we have &c&lEnergized Power&r, &3&lJust Dire Things&r, and &a&lEnderIO&r. \\n\\n&c&lEnergized Power&r and &a&lEnderIO&r are both very usual Tech Mods. Get &cEnergy&r, make Machines, use Machines. Neither of these have Quests at this time. \\n\\n&3&lJust Dire Things&r is unique as it uses Goo. Goo converts Blocks into Crystals, and Crystals can be made into Machines and Tools. Thankfully this one does have a Quest.",
   ],
   "quest.6CA3111E5B9FE80B.title": "&5&lApotheosis",
   "quest.39BC6F9F9EBBC22B.title": "&eBastion Remnants",
@@ -158,7 +158,7 @@
     "With &bDiamonds&r, &5Obsidian&r, and a &6Book&r we can make an &5Enchanting Table&r. \\n\\n&5Enchanting Tables&r will use &9Lapis&r and &aExperience&r to place &5Enchants&r on Gear. &5Enchants&r upgrade Gear, either giving more Drops, giving more Durability, or even setting things on &cFire&r! \\n\\nThe &5Enchants&r that you can get are set by the &5Enchanting Table's&r Level, which is set by &6Bookshelves&r. \\n\\nBut we also have &5&lApotheosis&r which adds to the mix of it.",
   ],
   "quest.06BF382F23E5C51F.quest_desc": [
-    "Armor is pretty necessary for Survival. \\n\\nArmor when worn gives Armor Points. Armor Points negate a certain amount of &4Damage&r. The more Points, the less &4Damage&r you take. \\n\\nThere's also Armor Toughness which comes from &bDiamond&r and&c Netherite Armor&r. \\n\\nArmor Toughness acts as a buffer. If the &4Damage&r you would take is below a certain threshold it will be negated. There's a specific formula for it but I'm not putting all of that in here.",
+    "Armor is pretty necessary for Survival. \\n\\nArmor when worn gives Armor Points. Armor Points negate a certain amount of &4Damage&r. The more Points, the less &4Damage&r you take. \\n\\nThere's also Armor Toughness which comes from &bDiamond&r and&c Netherite Armor&r. \\n\\nArmor Toughness has been reworked by &5&lApotheosis&r. It now lowers the effectiveness of armor reduction (from the Armor Pierce and Armor Shred attributes) from enemies. There's a specific formula for it but I'm not putting all of that in here.",
   ],
   "quest.1B3BBE40ABE68E69.title": "Greatest form of Storage",
   "quest.3FE25E22AFBC52E1.quest_desc": [

--- a/config/ftbquests/quests/lang/en_us/chapters/apotheosis_2.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/apotheosis_2.json5
@@ -87,7 +87,7 @@
     "Another game change Apotheosis brings is to Spawners. Remember being able to mine Spawners with Silk Touch? Well it's back thanks to Apotheosis! There's also many new Modifications you can add to Spawners by right clicking any of these items.",
   ],
   "quest.263860CADB3D76C6.quest_desc": [
-    "Powered Spawner is the Mob Spawner made using EnderIO. First, you'll need a filled Soul Vial and a Broken Spawner. (Technically you only need the Soul Vial to change the Spawner but that's whatever). Once you have a Broken Spawner you like, craft the Powered Spawner with it! Then, place it down, give it a Capacitor, and power it. Boom! now you are spawning mobs with EnderIO.\\n\\nYou can also make this Spawner fill Soul Vials directly, without the need of a Clicker.",
+    "Powered Spawner is the Mob Spawner made using EnderIO. First, you'll need a filled Soul Vial and a Broken Spawner. (Technically you only need the Soul Vial to change the Spawner but that's whatever). Once you have a Broken Spawner you like, craft the Powered Spawner with it! Then, place it down, give it a Capacitor, and power it. Boom! now you are spawning mobs with EnderIO.\n\nYou can also make this Spawner fill Soul Vials directly, without the need of a Clicker.",
   ],
   "quest.6D3B958E49AE7BDB.quest_desc": [
     "Charm Fragments can be made either into Charms or Spawn Eggs. They are from Reliquary and rarely drop from their respective mobs. Some can even be crafted! Take 2 and a normal Egg and you can craft a Spawn Egg.",

--- a/config/ftbquests/quests/lang/en_us/chapters/apotheosis_2.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/apotheosis_2.json5
@@ -1,4 +1,10 @@
 {
+  "quest.321C15EBBE2D3D30.quest_desc": [
+    "When you blow up a Spawner, it will become highly unstable, spawning a large amount of its respective mob, and leaving Spawner Chains behind.\\n\\nHow many chains, you might be wondering? At the time of writing, 48-57.\\n\\nYou'll need these Chains for...",
+  ],
+  "quest.7AC6A958936636D9.quest_desc": [
+    "The &aMountaineer's Spawner Upgrade Rune&r is the 3rd tier of Spawner Upgrade Runes. Yes, you'll need to fight a Warden for this.\\n\\nIt sets Minimum Spawn Delay to 50, Maximum Spawn Delay to 200, Spawn Count to 13, Max Entities to 24, and Activation Range to 40.",
+  ],
   "quest.0F0E227FC3EC0D90.quest_desc": [
     "These are spawners provided by mods besides Apothic Spawners.",
   ],
@@ -11,16 +17,21 @@
   "quest.223A5BDB5056B781.quest_desc": [
     "Capturing is an Enchantment for Swords to make Mobs rarely drop their Eggs. It's a rare one so keep looking for one and check out &5&lApothic Enchanting&r to help. Every level gives you a 0.5% chance at getting an Egg each kill and the highest level you can normally get is VII (7).",
   ],
+  "quest.321C15EBBE2D3D30.title": "Blowing up Spawners",
   "quest.77A8E8122870BBCE.quest_desc": [
     "This is technically not a Spawn Egg, but I'm including it here anyway, due to its ability to bind mobs to Spawners. Check out the &5&lApothic Enchanting&r chapter to learn more about how to get this Lead.",
   ],
+  "quest.503AC506720FC59E.quest_desc": [
+    "For more advanced modifications to Spawners, you'll need to &d&lInfuse&r your Spawner Runes.\\n\\n\\We'll need at least &a70 Eterna&r, &c30% Quanta&r, and &550% Arcana&r in an &5Enchanting Table&r. \\n\\nTo get that, we can use either of the following:\\n\\n14 &9Deepshelves&r, that aren't &9Dormant&r!\\n12 &4Glowing Hellshelves&r and 2 &9Deepshelves&r!\\n12 &bCrystalline Seashelves&r and 2 &9Deepshelves&r!\\n\\nCheck out the &5&lApothic Enchanting&r chapter to learn more about these mechanics.",
+  ],
   "quest.4F7F8F4ED1CA0550.quest_desc": [
-    "A Campfire used on the spawner will have the mobs spawn on fire. Perfect for a nice Steak.",
+    "A Rune of Immolation used on the spawner will have the mobs spawn on fire. Perfect for a nice Steak.",
   ],
   "quest.167E1474644C9908.quest_desc": [
-    "The Quartz makes whatever the other item does, it does the opposite for the Spawner. With Quartz in your offhand and the other Spawner Modification item in your main it will do the opposite of its role. With Quartz and Blaze Rods instead of increasing Spawn Range it will decrease it. With Quartz and Ghast Tears it'll decrease Max Entities.",
+    "The Quartz makes whatever the other item does, it does the opposite for the Spawner. With Quartz in your offhand and the other Spawner Modification item in your main it will do the opposite of its role. With Quartz and Runes of Spawning Range instead of increasing Spawn Range it will decrease it. With Quartz and Runes of Debilitation it'll increase Starting Health.",
   ],
   "task.55587BA32D30318C.title": "Spawn Eggs",
+  "quest.00C26068B55F4FD9.title": "Quiet down you'll wake up the mobs!",
   "quest.6D68D9941049E806.quest_desc": [
     "This spawner will, as its name implies, make use of &dSource&r as fuel. To decide on a mob to spawn, you'll need a Containment Jar holding the mob in the area.",
   ],
@@ -34,25 +45,31 @@
   "quest.186593EBCE3FE8D8.title": "Spawn Range",
   "task.524CBF7058496E7F.title": "Other Spawners",
   "quest.18E0F5A78F696FA3.quest_desc": [
-    "Echo shards give a special effect to the spawner. Any mobs spawned will have the loot that they drop multiplied.",
+    "Runes of Echoes give a special effect to the spawner. Any mobs spawned will have the loot that they drop multiplied.",
+  ],
+  "quest.00C26068B55F4FD9.quest_desc": [
+    "Runes of Silence only do one thing to the spawner and that's to shut it up. Don't like hearing the stupid Spawner noises? Then use a Rune of Silence!",
   ],
   "quest.0E02CE4469FCA4C9.quest_desc": [
     "Redstone Activation gives your spawner an on/off switch. Without Redstone Power it will not spawn.",
   ],
   "quest.6D68D9941049E806.quest_subtitle": "Ars Nouveau's Spawner",
   "quest.30EB438C66324213.quest_desc": [
-    "A Nether Star will do what the Prismarine Shards do but much better. Players no longer need to be near the spawner. As long as its chunk-loaded it will spawn.",
+    "A Rune of Solitude will do part what the Spawner Upgrade Runes do but much better. Players no longer need to be near the spawner. As long as its chunk-loaded it will spawn.",
   ],
   "quest.4F7F8F4ED1CA0550.title": "Burning",
   "task.45250DA4433007C6.title": "Capturing Books",
   "quest.6F71FD826C29C31A.title": "Youthful",
   "task.73B56F2139A98F77.title": "AllRightsReserved",
   "quest.0F89BFD4A3F63A48.quest_desc": [
-    "Some mobs (mostly monsters) need certain Light Levels to spawn. Hostile ones needing lower levels and passive needing higher ones. Using a Soul Lantern makes it so you never have to worry about Light Levels as it ignores them! This does not ignore other requirements for spawning like livestock animals needing Grass.",
+    "Some mobs (mostly monsters) need certain Light Levels to spawn. Hostile ones needing lower levels and passive needing higher ones. Using a Rune of Perpetual Twilight makes it so you never have to worry about Light Levels as it ignores them! This does not ignore other requirements for spawning like livestock animals needing Grass.",
   ],
   "quest.39E822440E7D2E04.quest_subtitle": "Mob Grinding Utils' Spawner",
   "quest.3F55F3CC8519D783.quest_subtitle": "Mystical Agriculture's Spawner",
   "quest.40096ED0B04C3EC5.title": "Ignore All Conditions",
+  "quest.17410BE15A81DD96.quest_desc": [
+    "The &aWayfarer's Spawner Upgrade Rune&r is the 2nd tier of Spawner Upgrade Runes.\\n\\nThis one sets Minimum Spawn Delay to 100, Maximum Spawn Delay to 400, Spawn Count to 10, Max Entities to 18, and Activation Range to 32.\\n\\nAny Spawn Egg works for crafting this Rune.",
+  ],
   "quest.30EB438C66324213.title": "Ignore Players",
   "quest.1102B27CBF564127.quest_subtitle": "Don't you despawn on me, Mobs",
   "quest.42D7C8CD8E6F5CD7.title": "No AI",
@@ -64,19 +81,23 @@
     "The Spawn Range is the area of where mobs can spawn. The bigger the area, the more room for them to spawn in. The smaller the area the cheaper the factory.",
   ],
   "quest.42D7C8CD8E6F5CD7.quest_desc": [
-    "By using a Chorus Fruit on a Spawner you suck the souls out the mobs that will be spawned, only leaving a hollow husk of what they used to be. The mobs will lose all AI so they will do basically what an armor stand does. They can't hit you, can't teleport, can't move on their own. They sit there ready to be killed, how exciting!",
+    "By using a Rune of Stupor on a Spawner you suck the souls out the mobs that will be spawned, only leaving a hollow husk of what they used to be. The mobs will lose all AI so they will do basically what an armor stand does. They can't hit you, can't teleport, can't move on their own. They sit there ready to be killed, how exciting!",
   ],
   "quest.310969B8FE0A94DE.quest_desc": [
     "Another game change Apotheosis brings is to Spawners. Remember being able to mine Spawners with Silk Touch? Well it's back thanks to Apotheosis! There's also many new Modifications you can add to Spawners by right clicking any of these items.",
   ],
   "quest.263860CADB3D76C6.quest_desc": [
-    "Powered Spawner is the Mob Spawner made using EnderIO. First, you'll need a filled Soul Vial and a Broken Spawner. (Technically you only need the Soul Vial to change the Spawner but that's whatever). Once you have a Broken Spawner you like, craft the Powered Spawner with it! Then, place it down, give it a Capacitor, and power it. Boom! now you are spawning mobs with EnderIO.\n\nYou can also make this Spawner fill Soul Vials directly, without the need of a Clicker.",
+    "Powered Spawner is the Mob Spawner made using EnderIO. First, you'll need a filled Soul Vial and a Broken Spawner. (Technically you only need the Soul Vial to change the Spawner but that's whatever). Once you have a Broken Spawner you like, craft the Powered Spawner with it! Then, place it down, give it a Capacitor, and power it. Boom! now you are spawning mobs with EnderIO.\\n\\nYou can also make this Spawner fill Soul Vials directly, without the need of a Clicker.",
   ],
   "quest.6D3B958E49AE7BDB.quest_desc": [
     "Charm Fragments can be made either into Charms or Spawn Eggs. They are from Reliquary and rarely drop from their respective mobs. Some can even be crafted! Take 2 and a normal Egg and you can craft a Spawn Egg.",
   ],
   "quest.7F6B66566C211735.quest_desc": [
-    "Dripstone used on the spawner will reduce the max health of the mob spawned. This can decrease their health to as low as 20%",
+    "Runes of Debilitation used on the spawner will reduce the max health of the mob spawned. This can decrease their health to as low as 20%",
+  ],
+  "quest.503AC506720FC59E.quest_subtitle": "Advanced Modifications",
+  "quest.17C87EB8ED8A27AB.quest_desc": [
+    "Spawner Runes are the base material for modifying Spawners.",
   ],
   "quest.21C2458FED19363C.quest_subtitle": "Industrial Foregoing's Spawner",
   "task.3B219688DA1CF9C8.title": "AllRightsReserved",
@@ -84,8 +105,12 @@
     "This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\n\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\n\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode.",
   ],
   "quest.0E02CE4469FCA4C9.title": "Redstone Active",
+  "quest.0E90577AC72749C4.quest_desc": [
+    "The &aThundering Spawner Upgrade Rune&r, the 4th and final tier of Spawner Upgrade Runes brings your Spawner to its highest potential.\\n\\nIt sets both Minimum and Maximum Spawn Delay to 20, Spawn Count to 16, Max Entities to 32, and Activation Range to 48.\\n\\nEndersurge Gems can be obtained in The End.",
+  ],
   "quest.77A8E8122870BBCE.quest_subtitle": "That's no Spawn Egg!",
   "quest.310969B8FE0A94DE.title": "Apothic Spawners",
+  "quest.17C87EB8ED8A27AB.quest_subtitle": "Basic Modifications",
   "quest.52FAF122466FDDC9.quest_desc": [
     "Stabilized Spawner is Draconic Evolution's version of the Spawner. When you use one of the Cores on a Spawner it will become a Stabilized Spawner. You can swap the Cores but you won't be able to change the stats as now they are set by the Cores. The better the Core the more mobs spawn and at a faster rate.",
   ],
@@ -96,6 +121,11 @@
     "The must-need for all Spawners. When it says ignores all conditions, it means most. Ignores light levels, blocks needing for spawning, and biomes. Space conditions are still needed though, like slimes needing 3x3 area to spawn, and same goes with players needing to be nearby.",
   ],
   "quest.0F89BFD4A3F63A48.title": "Ignore Light",
+  "quest.3F1430ADB648102F.quest_desc": [
+    "This Spawner Rune works differently than the rest. Instead of affecting one stat of the Spawner, it affects multiple at once. It also sets said stats to a specific amount instead of increasing or decreasing each time.\\n\\nThe &aFrontiersman's Spawner Upgrade Rune&r is the first of the Spawner Upgrade Runes, the cheapest, and, of course, weakest.\\n\\nIt sets Minimum Spawn Delay to 150, Maximum Spawn Delay to 600, Spawn Count to 7, Max Entities to 12, and Activation Range to 24.",
+    "{@pagebreak}",
+    "To determine when the Spawner will spawn it picks a random number between the Maximum and Minimum Spawn Delay. The speed is expressed in ticks where 20 ticks equals 1 second.\\n\\nThe Mobs spawned is random with a Maximum amount determined by the Spawn Count.\\n\\nMax entities is the amount of mobs that can be spawned by a spawner and kept. If it's only 6 max entities when 6 mobs are already spawned no more will spawned until they're dead or moved.\\n\\nActivation Range is how close the Player (You) must be to the Spawner for it to work.",
+  ],
   "quest.39E822440E7D2E04.quest_desc": [
     "Mob Grinding Utils is all about Mob Farming so of course it has a Spawner! The Entity Spawner! It'll need 3 things to work though: a Spawn Egg, XP Jelly Babies, and a Redstone signal. XP Jelly Babies are made by processing XP through a XP Solidifier with the XP Mould Jelly Baby. They can be eaten or used as Fuel in the second slot. Once you have the Spawn Egg in the top slot, XP Jelly Babies in the Second, and a Redstone signal it'll start spawning the mobs!",
   ],
@@ -104,7 +134,7 @@
   ],
   "task.24893D6EDE0BD819.title": "Mob Charm Fragments",
   "quest.6F71FD826C29C31A.quest_desc": [
-    "This one might be new to ones returning from earlier versions. By using a turtle egg on a spawner, it will only spawn in baby versions of the mobs in it. This only works with Vanilla baby versions of mobs, not modded.",
+    "This one might be new to ones returning from earlier versions. By using a Rune of Youth on a Spawner, it will only spawn in baby versions of the mobs in it. This only works with Vanilla baby versions of mobs, not modded.",
   ],
   "quest.72AE56D34834D28E.quest_desc": [
     "Another one from PneumaticCraft? Oh this one is the actual Spawner I see. Like the Draconic Stabilized Spawner you'll need a Vanilla Spawner first. Once you have one, place a Spawner Extrator above the Spawner and give it below -0.5 Bars to get it to work. Once it's done it'll give you a Spawner Core filled with whatever mob was in it and it will leave you with an Empty Spawner. Then use the Empty Spawner to craft a Pressurized Spawner and then put the Spawner Core into it. (To upgrade the Core use a Vacuum Trap to suck up the mobs that will go into the Spawner Core). Once you do that the Spawner will now need Pressure to work, ignores Light Level, and is Redstone Activated.",

--- a/config/ftbquests/quests/lang/en_us/chapters/apothic_enchanting.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/apothic_enchanting.json5
@@ -184,7 +184,7 @@
   ],
   "quest.4EE6824A970EEB35.title": "&d&lInfusing&r Spawner Runes",
   "quest.06F70F6CA37168CC.quest_desc": [
-    "The &6&oGem Case of House Fabergé&r is a better &5Gem Case&r. \\n\\nIt can hold higher amounts of &aGems&r.\\n\\nThe &5Gem Case&r can hold 32768, while the &6&oGem Case of House Fabergé&r can hold 2.1 Billion of each unique &aGem&r! \\n\\nTo obtain it, we'll need to &d&lInfuse&r the &5Gem Case&r. \\n\\nUse 4 &9Soul-Touched Sculkshelves&f, 4 &9Echoing Sculkshelves&f, 1 &dDraconic Endshelf&f, 7 &7Stoneshelves&r, and 11 &7Basic Bookshelves&r.",
+    "The &6&oGem Case of House Fabergé&r is a better &5Gem Case&r. \\n\\nIt can hold higher amounts of &aGems&r.\\n\\nThe &5Gem Case&r can hold 32768, while the &6&oGem Case of House Fabergé&r can hold 2.1 Billion of each unique &aGem&r! \\n\\nTo obtain it, we'll need to &d&lInfuse&r the &5Gem Case&r. \\n\\nUse 4 &9Soul-Touched Sculkshelves&f, 4 &9Echoing Sculkshelves&f, 2 &dDraconic Endshelves&f, 7 &7Stoneshelves&r, and 1 &7Basic Bookshelf&r.",
   ],
   "quest.7C758209D06ED0E3.title": "&4Glowing Hellshelf",
   "quest.191A7F3C9FBA4C13.title": "&bCrystalline Seashelf",


### PR DESCRIPTION
Chapter 1:
- Adjusted dependencies for The End and Ender Dragon to follow a more logical sense of progression
- Implied that certain mods will receive quests in the future.
- Changed "Ancient Scraps" to "Netherite Scraps"
- Adjust Armor Toughness in Armor to refer to the reworked version by Apotheosis (actually Apothic Attributes but I'll just call it Apotheosis)

~~Apothic Spawners:~~
~~- Unreverted a bunch of my lang file changes~~ (did not realize this was already done)

Apothic Enchanting
- Changed up the Gem Case of House Fabergé's Infusion setup to use fewer Basic Bookshelves and more Draconic Endshelves (to match ATM10 and Mons)