### PR TITLE
fix: Remove unnecessary components from a certain quest

### DIFF
--- a/config/ftbquests/quests/chapters/applied_energistics_2.json5
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.json5
@@ -2591,14 +2591,8 @@
             id: "occultism:divination_rod",
             count: 1,
             components: {
-              "occultism:divination_distance": 0.0,
               "occultism:divination_linked_block": "ae2:mysterious_cube",
               "minecraft:custom_name": "Meteorite Divination Rod",
-              "occultism:divination_pos": [
-                -4438,
-                253,
-                2352,
-              ],
             },
           },
           match_components: "fuzzy",


### PR DESCRIPTION
Particularly, from AE2's Meteorite Divination Rod quest
Had an oopsie where I used an "used" version of the Meteorite Divination Rod instead of a "fresh" one