### PR TITLE
Prevent Infinity Bimetal Gear from being uncraftable

### DIFF
--- a/kubejs/server_scripts/unification/gears.js
+++ b/kubejs/server_scripts/unification/gears.js
@@ -25,8 +25,9 @@ ServerEvents.recipes((allthemods) => {
   allthemods.remove({ id: "industrialforegoing:iron_gear" })
   allthemods.remove({ id: "industrialforegoing:gold_gear" })
   allthemods.remove({ id: "industrialforegoing:diamond_gear" })
-  allthemods.remove({ id: "enderio:iron_gear" })
-  allthemods.remove({ id: "enderio:wood_gear_corner" })
+  if (Platform.isLoaded("almostunified")) {
+	  allthemods.remove({ id: "enderio:iron_gear" })
+  }
   allthemods.remove({ id: "pneumaticcraft:compressed_iron_gear" })
 
   if (Platform.isLoaded("pneumaticcraft")) {


### PR DESCRIPTION
At least while Almost Unified is not installed.
If this is the wrong solution for making Inhibition Obelisk craftable (it's the only thing that is picky about wanting the bimetal gear), I'd gladly accept making that use any iron gear instead.