### PR TITLE
Re-Enable Arcane Catalyst and remove Cheaty Alloy Recipes

### DIFF
--- a/kubejs/server_scripts/mods/oritech/recipes.js
+++ b/kubejs/server_scripts/mods/oritech/recipes.js
@@ -74,17 +74,18 @@ if (Platform.isLoaded("oritech")) {
       time: 120
     })
     // Remove enchanting stuff
-    allthemods.remove({ id: "oritech:crafting/catalyst_alt" })
-    allthemods.remove({ id: "oritech:crafting/catalyst" })
-    allthemods.remove({ id: "oritech:crafting/enchanter" })
-    allthemods.remove({ id: "minecraft:crafting/catalyst_alt" })
-    allthemods.remove({ id: "minecraft:crafting/catalyst" })
-    allthemods.remove({ id: "minecraft:crafting/enchanter" })
+    // allthemods.remove({ id: "oritech:crafting/catalyst_alt" })
+    // allthemods.remove({ id: "oritech:crafting/catalyst" })
+    // allthemods.remove({ id: "oritech:crafting/enchanter" })
+    // allthemods.remove({ id: "minecraft:crafting/catalyst_alt" })
+    // allthemods.remove({ id: "minecraft:crafting/catalyst" })
+    // allthemods.remove({ id: "minecraft:crafting/enchanter" })
     // Cheaty alloys
     allthemods.remove({ id: "oritech:steel_ingot" })
     allthemods.remove({ id: "oritech:electrum_ingot" })
 	// Alternate Tainted Refinery recipe
-	if (Platform.isLoaded("apothic_enchanting")) {
+	// To be revisited another time
+	/* if (Platform.isLoaded("apothic_enchanting")) {
 		allthemods.custom({
 			  "type": "oritech:machine_recipe",
 			  "itemInputs": [
@@ -99,7 +100,7 @@ if (Platform.isLoaded("oritech")) {
 			  "recipeType": "oritech:particle_collision",
 			  "time": 6000
 			}).id("allthemods:tainted_refinery")
-	}
+	} */
   })
 }
 

--- a/kubejs/server_scripts/mods/oritech/recipes.js
+++ b/kubejs/server_scripts/mods/oritech/recipes.js
@@ -81,10 +81,25 @@ if (Platform.isLoaded("oritech")) {
     allthemods.remove({ id: "minecraft:crafting/catalyst" })
     allthemods.remove({ id: "minecraft:crafting/enchanter" })
     // Cheaty alloys
-    allthemods.remove({ id: "oritech:crafting/alloy/steel" })
-    allthemods.remove({ id: "oritech:crafting/alloy/electrum" })
-    allthemods.remove({ id: "minecraft:crafting/alloy/steel" })
-    allthemods.remove({ id: "minecraft:crafting/alloy/electrum" })
+    allthemods.remove({ id: "oritech:steel_ingot" })
+    allthemods.remove({ id: "oritech:electrum_ingot" })
+	// Alternate Tainted Refinery recipe
+	if (Platform.isLoaded("apothic_enchanting")) {
+		allthemods.custom({
+			  "type": "oritech:machine_recipe",
+			  "itemInputs": [
+				  "oritech:refinery",
+				  "apothic_enchanting:echoing_sculkshelf"
+			  ],
+			  "itemResults": [
+				{
+				  "id": "oritech:tainted_refinery"
+				}
+			  ],
+			  "recipeType": "oritech:particle_collision",
+			  "time": 6000
+			}).id("allthemods:tainted_refinery")
+	}
   })
 }
 


### PR DESCRIPTION
The cheaty alloy recipes were supposed to be removed, but Oritech changed the ID of those...so I'm accounting for that.
~~Additionally, this Pull Request aims to create a similar Tainted Refinery recipe as https://github.com/AllTheMods/All-the-Mons/pull/672, except using an Echoing Sculkshelf instead of a Soul Crystal since we do not have Deeper and Darker at this time.~~
<img width="597" height="236" alt="image" src="https://github.com/user-attachments/assets/2689bcf9-c7ca-4549-96c3-b31bab1ce74f" />
