### PR TITLE
A bunch of Quest Changes

### DIFF
--- a/config/ftbquests/quests/chapters/apotheosis_2.json5
+++ b/config/ftbquests/quests/chapters/apotheosis_2.json5
@@ -911,9 +911,9 @@
       ],
       rewards: [
         {
-          id: "7D66827934F17D92",
-          type: "xp_levels",
-          xp_levels: 50,
+          id: "1F9ED11417D13394",
+          type: "xp",
+          xp: 50,
         },
       ],
     },
@@ -936,9 +936,9 @@
       ],
       rewards: [
         {
-          id: "39962F3D8EB1C56B",
-          type: "xp_levels",
-          xp_levels: 100,
+          id: "0BC7D27134BD341C",
+          type: "xp",
+          xp: 100,
         },
       ],
     },

--- a/config/ftbquests/quests/chapters/applied_energistics_2.json5
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.json5
@@ -842,6 +842,7 @@
         "5F56892CD904C40F",
         "286AC3AA3D4A72BA",
       ],
+      hide_until_deps_complete: true,
       size: 1.5,
       id: "460A8F17F3ED6CAF",
       tasks: [
@@ -2429,6 +2430,7 @@
         "361CCBD353D6FF34",
         "286AC3AA3D4A72BA",
       ],
+      hide_until_deps_complete: true,
       id: "0F03E75CF79BADD7",
       tasks: [
         {
@@ -2462,7 +2464,6 @@
       dependencies: [
         "0B218DD73FE8D985",
         "16299B9AE87257DC",
-        "286AC3AA3D4A72BA",
       ],
       id: "4B76FE0348DB0E45",
       tasks: [
@@ -2470,11 +2471,8 @@
           id: "16E78B6C132910B5",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ae2wtlib:quantum_bridge_card",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ae2wtlib:quantum_bridge_card",
-            },
           },
         },
       ],

--- a/config/ftbquests/quests/chapters/elmystical_agriculturerr.json5
+++ b/config/ftbquests/quests/chapters/elmystical_agriculturerr.json5
@@ -49,10 +49,10 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "patchouli:guide_book",
         count: 1,
         components: {
-          "ftbquests:missing_item": "patchouli:guide_book",
+          "patchouli:book": "mysticalagriculture:guide",
         },
       },
       x: 0.0,
@@ -83,10 +83,10 @@
           id: "2B066A28F827460C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "patchouli:guide_book",
             count: 1,
             components: {
-              "ftbquests:missing_item": "patchouli:guide_book",
+              "patchouli:book": "mysticalagriculture:guide",
             },
           },
         },

--- a/config/ftbquests/quests/chapters/extended__advanced_ae.json5
+++ b/config/ftbquests/quests/chapters/extended__advanced_ae.json5
@@ -156,7 +156,7 @@
             id: "ftbfiltersystem:smart_filter",
             count: 1,
             components: {
-              "ftbfiltersystem:filter": "or(item(extendedae:ex_import_bus_part)item(extendedae:ex_export_bus_part)item(extendedae:ex_charger)item(extendedae:ex_inscriber)item(extendedae:ex_molecular_assembler)item(extendedae:ex_drive)item(extendedae:ex_io_port)item(extendedae:ex_interface)item(extendedae:ex_pattern_provider))",
+              "ftbfiltersystem:filter": "or(item(extendedae:ex_import_bus_part)item(extendedae:ex_export_bus_part)item(extendedae:ex_charger)item(extendedae:ex_molecular_assembler)item(extendedae:ex_drive)item(extendedae:ex_io_port)item(extendedae:ex_interface)item(extendedae:ex_pattern_provider))",
             },
           },
         },

--- a/config/ftbquests/quests/chapters/generators.json5
+++ b/config/ftbquests/quests/chapters/generators.json5
@@ -3,14 +3,77 @@
   group: "49AECADBA9E79A3B",
   order_index: 2,
   icon: {
-    id: "ftbquests:missing_item",
+    id: "ironfurnaces:million_furnace",
     count: 1,
     components: {
-      "ftbquests:missing_item": "ironfurnaces:million_furnace",
+      "minecraft:custom_name": {
+        text: "",
+        extra: [
+          {
+            text: "R",
+            color: "blue",
+          },
+          {
+            text: "a",
+            color: "red",
+          },
+          {
+            text: "i",
+            color: "yellow",
+          },
+          {
+            text: "n",
+            color: "red",
+          },
+          {
+            text: "b",
+            color: "green",
+          },
+          {
+            text: "o",
+            color: "green",
+          },
+          {
+            text: "w",
+            color: "blue",
+          },
+          {
+            text: " ",
+            color: "aqua",
+          },
+          {
+            text: "F",
+            color: "aqua",
+          },
+          {
+            text: "u",
+            color: "yellow",
+          },
+          {
+            text: "r",
+            color: "green",
+          },
+          {
+            text: "n",
+            color: "blue",
+          },
+          {
+            text: "a",
+            color: "blue",
+          },
+          {
+            text: "c",
+            color: "blue",
+          },
+          {
+            text: "e",
+            color: "blue",
+          },
+        ],
+      },
     },
   },
   filename: "generators",
-  always_invisible: true,
   default_quest_shape: "square",
   default_hide_dependency_lines: false,
   quests: [
@@ -20,7 +83,6 @@
       shape: "square",
       dependencies: [
         "47750F3CB020104C",
-        "3876FDC471FC460B",
       ],
       id: "2748ACEAB96A5F60",
       tasks: [
@@ -28,11 +90,8 @@
           id: "3FA02C4DF722D831",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:iron_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:iron_furnace",
-            },
           },
         },
       ],
@@ -41,11 +100,8 @@
           id: "418B0AB5F7210588",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_iron",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_iron",
-            },
           },
         },
         {
@@ -66,7 +122,6 @@
       dependencies: [
         "2748ACEAB96A5F60",
         "61847F47CCA225D9",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "420FE84DEE12CCE0",
@@ -75,11 +130,8 @@
           id: "6F39535100663F77",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:gold_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:gold_furnace",
-            },
           },
         },
       ],
@@ -88,22 +140,16 @@
           id: "5F055AFC53D8DF42",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_gold2",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_gold2",
-            },
           },
         },
         {
           id: "039B7D0DBE44C9B5",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_gold",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_gold",
-            },
           },
         },
         {
@@ -123,7 +169,6 @@
       shape: "square",
       dependencies: [
         "420FE84DEE12CCE0",
-        "3876FDC471FC460B",
       ],
       id: "21EA29A8C7F950CE",
       tasks: [
@@ -131,11 +176,8 @@
           id: "077252C1A4175920",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:diamond_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:diamond_furnace",
-            },
           },
         },
       ],
@@ -144,11 +186,8 @@
           id: "6926332F80711102",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_diamond",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_diamond",
-            },
           },
         },
         {
@@ -168,7 +207,6 @@
       shape: "square",
       dependencies: [
         "21EA29A8C7F950CE",
-        "3876FDC471FC460B",
       ],
       id: "711DDD55CEC439E5",
       tasks: [
@@ -176,11 +214,8 @@
           id: "6ECF5BA47D176D7D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:emerald_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:emerald_furnace",
-            },
           },
         },
       ],
@@ -189,11 +224,8 @@
           id: "2EFFB4B2C0EB3B54",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_emerald",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_emerald",
-            },
           },
         },
         {
@@ -214,7 +246,6 @@
       dependencies: [
         "2354BC5330350DF6",
         "711DDD55CEC439E5",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "32C7D8AE859BF89E",
@@ -223,11 +254,8 @@
           id: "694E0730B29BEF80",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:obsidian_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:obsidian_furnace",
-            },
           },
         },
       ],
@@ -236,11 +264,8 @@
           id: "08C0ADB3F26DC561",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_obsidian2",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_obsidian2",
-            },
           },
         },
         {
@@ -260,7 +285,6 @@
       shape: "square",
       dependencies: [
         "21EA29A8C7F950CE",
-        "3876FDC471FC460B",
       ],
       id: "2354BC5330350DF6",
       tasks: [
@@ -268,11 +292,8 @@
           id: "26CE85F193784F9D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:crystal_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:crystal_furnace",
-            },
           },
         },
       ],
@@ -281,11 +302,8 @@
           id: "53A5D4B1905A19D3",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_crystal",
-            },
           },
         },
         {
@@ -305,7 +323,6 @@
       shape: "square",
       dependencies: [
         "47750F3CB020104C",
-        "3876FDC471FC460B",
       ],
       id: "661C072E48F8D41F",
       tasks: [
@@ -313,11 +330,8 @@
           id: "60B2B799FB293974",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:copper_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:copper_furnace",
-            },
           },
         },
       ],
@@ -326,11 +340,8 @@
           id: "339B00F7AB29615F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_copper",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_copper",
-            },
           },
         },
         {
@@ -350,7 +361,6 @@
       dependencies: [
         "661C072E48F8D41F",
         "2748ACEAB96A5F60",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "61847F47CCA225D9",
@@ -359,11 +369,8 @@
           id: "6828EEA56791555C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:silver_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:silver_furnace",
-            },
           },
         },
       ],
@@ -372,22 +379,16 @@
           id: "1C9C045DFB87E87B",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_silver",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_silver",
-            },
           },
         },
         {
           id: "3795E50309E6A7A8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_iron2",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_iron2",
-            },
           },
         },
         {
@@ -409,7 +410,6 @@
       dependencies: [
         "0AD2B11565B484E7",
         "7A615E2A152917AD",
-        "3876FDC471FC460B",
       ],
       hide_until_deps_visible: true,
       hide_details_until_startable: true,
@@ -419,10 +419,74 @@
           id: "0B62A5DC9EB8E6CF",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:million_furnace",
             count: 1,
             components: {
-              "ftbquests:missing_item": "ironfurnaces:million_furnace",
+              "minecraft:custom_name": {
+                text: "",
+                extra: [
+                  {
+                    text: "R",
+                    color: "green",
+                  },
+                  {
+                    text: "a",
+                    color: "green",
+                  },
+                  {
+                    text: "i",
+                    color: "blue",
+                  },
+                  {
+                    text: "n",
+                    color: "yellow",
+                  },
+                  {
+                    text: "b",
+                    color: "aqua",
+                  },
+                  {
+                    text: "o",
+                    color: "red",
+                  },
+                  {
+                    text: "w",
+                    color: "yellow",
+                  },
+                  {
+                    text: " ",
+                    color: "yellow",
+                  },
+                  {
+                    text: "F",
+                    color: "aqua",
+                  },
+                  {
+                    text: "u",
+                    color: "blue",
+                  },
+                  {
+                    text: "r",
+                    color: "aqua",
+                  },
+                  {
+                    text: "n",
+                    color: "green",
+                  },
+                  {
+                    text: "a",
+                    color: "light_purple",
+                  },
+                  {
+                    text: "c",
+                    color: "blue",
+                  },
+                  {
+                    text: "e",
+                    color: "yellow",
+                  },
+                ],
+              },
             },
           },
         },
@@ -450,9 +514,6 @@
       shape: "gear",
       hide_dependency_lines: true,
       hide_dependent_lines: true,
-      dependencies: [
-        "3876FDC471FC460B",
-      ],
       size: 2.0,
       id: "47750F3CB020104C",
       tasks: [
@@ -484,6 +545,7 @@
         "47750F3CB020104C",
         "3876FDC471FC460B",
       ],
+      hide_until_deps_complete: true,
       id: "618F1434757C8E69",
       tasks: [
         {
@@ -1078,7 +1140,6 @@
       shape: "square",
       dependencies: [
         "32C7D8AE859BF89E",
-        "3876FDC471FC460B",
       ],
       id: "79C4CF8D7312FC28",
       tasks: [
@@ -1086,11 +1147,8 @@
           id: "7396676DE78C892F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:netherite_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:netherite_furnace",
-            },
           },
         },
       ],
@@ -1099,11 +1157,8 @@
           id: "7B10BDA090A6930E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_netherite",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_netherite",
-            },
           },
         },
         {
@@ -1124,7 +1179,6 @@
       dependencies: [
         "661C072E48F8D41F",
         "2748ACEAB96A5F60",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "78D1C97A542133D8",
@@ -1145,7 +1199,6 @@
       shape: "rsquare",
       dependencies: [
         "78D1C97A542133D8",
-        "3876FDC471FC460B",
       ],
       size: 1.0,
       icon_scale: 1.5,
@@ -1155,11 +1208,8 @@
           id: "20DE2F2B898D0005",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:augment_blasting",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:augment_blasting",
-            },
           },
         },
       ],
@@ -1181,7 +1231,6 @@
       shape: "rsquare",
       dependencies: [
         "78D1C97A542133D8",
-        "3876FDC471FC460B",
       ],
       icon_scale: 1.5,
       id: "33436ED0D9F128BD",
@@ -1190,11 +1239,8 @@
           id: "758315445FF03189",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:augment_smoking",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:augment_smoking",
-            },
           },
         },
       ],
@@ -1216,7 +1262,6 @@
       shape: "rsquare",
       dependencies: [
         "78D1C97A542133D8",
-        "3876FDC471FC460B",
       ],
       icon_scale: 1.5,
       id: "49F08DE190AAD0D8",
@@ -1225,11 +1270,8 @@
           id: "43956CC225D2571B",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:augment_factory",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:augment_factory",
-            },
           },
         },
       ],
@@ -1251,7 +1293,6 @@
       shape: "rsquare",
       dependencies: [
         "78D1C97A542133D8",
-        "3876FDC471FC460B",
       ],
       icon_scale: 1.5,
       id: "07753C5D94312A50",
@@ -1260,11 +1301,8 @@
           id: "4C75C05EDFA9A697",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:augment_generator",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:augment_generator",
-            },
           },
         },
       ],
@@ -1285,7 +1323,6 @@
       shape: "rsquare",
       dependencies: [
         "78D1C97A542133D8",
-        "3876FDC471FC460B",
       ],
       icon_scale: 1.5,
       id: "7F67849DE9F700D8",
@@ -1294,11 +1331,8 @@
           id: "4E8DC26DF9905F9C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:augment_speed",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:augment_speed",
-            },
           },
         },
       ],
@@ -1320,7 +1354,6 @@
       shape: "rsquare",
       dependencies: [
         "78D1C97A542133D8",
-        "3876FDC471FC460B",
       ],
       icon_scale: 1.5,
       id: "538821E23E39BE97",
@@ -1329,11 +1362,8 @@
           id: "121305057D3E8015",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:augment_fuel",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:augment_fuel",
-            },
           },
         },
       ],
@@ -1356,7 +1386,6 @@
       dependencies: [
         "2748ACEAB96A5F60",
         "661C072E48F8D41F",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "686B25F2E9D8CC97",
@@ -1365,11 +1394,8 @@
           id: "1C9D63BCE843C437",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:item_spooky",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:item_spooky",
-            },
           },
         },
       ],
@@ -1394,7 +1420,6 @@
       dependencies: [
         "2748ACEAB96A5F60",
         "661C072E48F8D41F",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "553220A2CD7CAFE4",
@@ -1403,11 +1428,8 @@
           id: "5EE98EB3DC0E291F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:item_xmas",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:item_xmas",
-            },
           },
         },
       ],
@@ -1432,7 +1454,6 @@
       dependencies: [
         "661C072E48F8D41F",
         "2748ACEAB96A5F60",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "20EC8001A05CE2C8",
@@ -1441,22 +1462,16 @@
           id: "45C945406D8C21A7",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:heater",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:heater",
-            },
           },
         },
         {
           id: "48E37342F58C067C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:item_heater",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:item_heater",
-            },
           },
         },
       ],
@@ -1479,7 +1494,6 @@
       shape: "square",
       dependencies: [
         "79C4CF8D7312FC28",
-        "3876FDC471FC460B",
       ],
       hide_until_deps_visible: true,
       hide_details_until_startable: true,
@@ -1489,11 +1503,8 @@
           id: "2CC59DECF8DCA48E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:rainbow_core",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:rainbow_core",
-            },
           },
         },
       ],
@@ -1502,11 +1513,8 @@
           id: "6CC7A041EA0C54D0",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:netherite_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:netherite_furnace",
-            },
           },
         },
         {
@@ -1534,7 +1542,6 @@
         "61847F47CCA225D9",
         "711DDD55CEC439E5",
         "32C7D8AE859BF89E",
-        "3876FDC471FC460B",
       ],
       hide_until_deps_visible: true,
       hide_details_until_startable: true,
@@ -1544,11 +1551,8 @@
           id: "1364DC251AC7325A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:rainbow_plating",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "8x ironfurnaces:rainbow_plating",
-            },
           },
           count: 8,
         },
@@ -1558,11 +1562,8 @@
           id: "1CBB74563FE53945",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:crystal_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:crystal_furnace",
-            },
           },
         },
         {
@@ -1581,7 +1582,6 @@
       y: 3.0,
       dependencies: [
         "2EE8FCB63A338BC4",
-        "3876FDC471FC460B",
       ],
       hide_until_deps_visible: true,
       hide_details_until_startable: true,
@@ -1591,11 +1591,8 @@
           id: "7074C679F7E9CC65",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:rainbow_coal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:rainbow_coal",
-            },
           },
         },
       ],
@@ -1614,7 +1611,6 @@
       dependencies: [
         "661C072E48F8D41F",
         "2748ACEAB96A5F60",
-        "3876FDC471FC460B",
       ],
       dependency_requirement: "one_completed",
       id: "757B14D08A9A03C4",
@@ -1623,11 +1619,8 @@
           id: "087F1F4ABAEABEE3",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:item_copy",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:item_copy",
-            },
           },
         },
       ],
@@ -1658,7 +1651,6 @@
         "711DDD55CEC439E5",
         "32C7D8AE859BF89E",
         "79C4CF8D7312FC28",
-        "3876FDC471FC460B",
       ],
       hide_until_deps_visible: true,
       id: "0ADBE90B33ACC9FB",
@@ -1667,10 +1659,74 @@
           id: "1E571965015CB5C6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:million_furnace",
             count: 1,
             components: {
-              "ftbquests:missing_item": "ironfurnaces:million_furnace",
+              "minecraft:custom_name": {
+                text: "",
+                extra: [
+                  {
+                    text: "R",
+                    color: "yellow",
+                  },
+                  {
+                    text: "a",
+                    color: "green",
+                  },
+                  {
+                    text: "i",
+                    color: "aqua",
+                  },
+                  {
+                    text: "n",
+                    color: "green",
+                  },
+                  {
+                    text: "b",
+                    color: "yellow",
+                  },
+                  {
+                    text: "o",
+                    color: "red",
+                  },
+                  {
+                    text: "w",
+                    color: "green",
+                  },
+                  {
+                    text: " ",
+                    color: "blue",
+                  },
+                  {
+                    text: "F",
+                    color: "aqua",
+                  },
+                  {
+                    text: "u",
+                    color: "green",
+                  },
+                  {
+                    text: "r",
+                    color: "light_purple",
+                  },
+                  {
+                    text: "n",
+                    color: "red",
+                  },
+                  {
+                    text: "a",
+                    color: "red",
+                  },
+                  {
+                    text: "c",
+                    color: "light_purple",
+                  },
+                  {
+                    text: "e",
+                    color: "green",
+                  },
+                ],
+              },
             },
           },
         },
@@ -1678,99 +1734,72 @@
           id: "76F4E8E39E65DE8E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:copper_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:copper_furnace",
-            },
           },
         },
         {
           id: "609F73623D8C1115",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:iron_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:iron_furnace",
-            },
           },
         },
         {
           id: "3309793C433ED961",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:silver_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:silver_furnace",
-            },
           },
         },
         {
           id: "5591ADC1C86DF4C9",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:gold_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:gold_furnace",
-            },
           },
         },
         {
           id: "3C67BBF2E866071D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:diamond_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:diamond_furnace",
-            },
           },
         },
         {
           id: "1FEA3210D56357D3",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:emerald_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:emerald_furnace",
-            },
           },
         },
         {
           id: "19CB7D9D615F95B7",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:crystal_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:crystal_furnace",
-            },
           },
         },
         {
           id: "6C031CF27E690421",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:obsidian_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:obsidian_furnace",
-            },
           },
         },
         {
           id: "461287CF29534C60",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:netherite_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:netherite_furnace",
-            },
           },
         },
       ],
@@ -1873,9 +1902,6 @@
       x: 0.0,
       y: -1.5,
       shape: "circle",
-      dependencies: [
-        "3876FDC471FC460B",
-      ],
       optional: true,
       invisible: true,
       id: "39605F1FEB1A5A1C",
@@ -1895,7 +1921,6 @@
       y: 5.0,
       dependencies: [
         "79C4CF8D7312FC28",
-        "3876FDC471FC460B",
       ],
       optional: true,
       id: "3A4C17878FC8315B",
@@ -1904,11 +1929,8 @@
           id: "710A1EE625BB05C2",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:allthemodium_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:allthemodium_furnace",
-            },
           },
         },
       ],
@@ -1917,11 +1939,8 @@
           id: "267CF2D64101DD03",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_allthemodium",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_allthemodium",
-            },
           },
         },
         {
@@ -1940,7 +1959,6 @@
       y: 6.0,
       dependencies: [
         "3A4C17878FC8315B",
-        "3876FDC471FC460B",
       ],
       optional: true,
       id: "2E85D6E2CFCC356E",
@@ -1949,11 +1967,8 @@
           id: "4F5816CE50B317C9",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:vibranium_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:vibranium_furnace",
-            },
           },
         },
       ],
@@ -1962,11 +1977,8 @@
           id: "66D125B9640849E3",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_vibranium",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_vibranium",
-            },
           },
         },
         {
@@ -1985,7 +1997,6 @@
       y: 6.0,
       dependencies: [
         "2E85D6E2CFCC356E",
-        "3876FDC471FC460B",
       ],
       optional: true,
       id: "25080E3295B1DF01",
@@ -1994,11 +2005,8 @@
           id: "219B80EF2B90BBFD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:unobtainium_furnace",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:unobtainium_furnace",
-            },
           },
         },
       ],
@@ -2007,11 +2015,8 @@
           id: "54105E0656B25E8A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "ironfurnaces:upgrade_unobtainium",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "ironfurnaces:upgrade_unobtainium",
-            },
           },
         },
         {

--- a/config/ftbquests/quests/chapters/justdirethings.json5
+++ b/config/ftbquests/quests/chapters/justdirethings.json5
@@ -28,10 +28,10 @@
           id: "4AE9DB73FB6C1EBC",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "patchouli:guide_book",
             count: 1,
             components: {
-              "ftbquests:missing_item": "patchouli:guide_book",
+              "patchouli:book": "justdirethings:justdirethingsbook",
             },
           },
         },

--- a/config/ftbquests/quests/chapters/occultism.json5
+++ b/config/ftbquests/quests/chapters/occultism.json5
@@ -1,7 +1,7 @@
 {
   id: "4C507C004144BFEE",
   group: "02FE661031A105D8",
-  order_index: 7,
+  order_index: 6,
   icon: {
     id: "occultism:ritual_dummy/summon_foliot_crusher",
     count: 1,
@@ -628,7 +628,7 @@
             id: "ftbfiltersystem:smart_filter",
             count: 1,
             components: {
-              "ftbfiltersystem:filter": "ftbfiltersystem:item_tag(occultism:miners/ores)",
+              "ftbfiltersystem:filter": "item_tag(occultism:miners)",
             },
           },
         },
@@ -654,16 +654,22 @@
           id: "1BBB313192F51FA8",
           type: "item",
           item: {
-            id: "occultism:storage_controller_base",
+            id: "ftbfiltersystem:smart_filter",
             count: 1,
+            components: {
+              "ftbfiltersystem:filter": "or(item(occultism:storage_controller_base)item(occultism:storage_controller_base_dark))",
+            },
           },
         },
         {
           id: "4EDB733716D494CE",
           type: "item",
           item: {
-            id: "occultism:storage_controller",
+            id: "ftbfiltersystem:smart_filter",
             count: 1,
+            components: {
+              "ftbfiltersystem:filter": "or(item(occultism:storage_controller_dark)item(occultism:storage_controller))",
+            },
           },
         },
         {
@@ -707,7 +713,7 @@
             id: "ftbfiltersystem:smart_filter",
             count: 1,
             components: {
-              "ftbfiltersystem:filter": "or(item(occultism:storage_stabilizer_tier1)item(occultism:storage_stabilizer_tier2)item(occultism:storage_stabilizer_tier3)item(occultism:storage_stabilizer_tier4))",
+              "ftbfiltersystem:filter": "or(item(occultism:storage_stabilizer_tier1)item(occultism:storage_stabilizer_tier2)item(occultism:storage_stabilizer_tier3)item(occultism:storage_stabilizer_tier4)item(occultism:storage_stabilizer_tier5)item(occultism:storage_stabilizer_tier1_dark)item(occultism:storage_stabilizer_tier2_dark)item(occultism:storage_stabilizer_tier3_dark)item(occultism:storage_stabilizer_tier4_dark)item(occultism:storage_stabilizer_tier5_dark))",
             },
           },
         },
@@ -764,8 +770,11 @@
           id: "792FA8ED0719803C",
           type: "item",
           item: {
-            id: "occultism:stable_wormhole",
+            id: "ftbfiltersystem:smart_filter",
             count: 1,
+            components: {
+              "ftbfiltersystem:filter": "or(item(occultism:stable_wormhole)item(occultism:stable_wormhole_dark))",
+            },
           },
         },
         {
@@ -2217,6 +2226,7 @@
       dependencies: [
         "690B89D23134B624",
       ],
+      optional: true,
       id: "54378277B8D28B1D",
       tasks: [
         {
@@ -2233,11 +2243,8 @@
           id: "2B2B8B432F1AF6A4",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "reliquary:void_tear",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "actuallyadditions:void_crystal",
-            },
           },
         },
       ],
@@ -2449,6 +2456,7 @@
       y: 11.5,
       dependencies: [
         "0BD6365534BF04D5",
+        "78ADF668D8022DFE",
       ],
       optional: true,
       invisible: true,
@@ -2486,7 +2494,9 @@
       y: 11.5,
       dependencies: [
         "4F35D04721DFC9FF",
+        "78ADF668D8022DFE",
       ],
+      hide_until_deps_complete: true,
       optional: true,
       id: "06B9D8973E9C6A2C",
       tasks: [
@@ -2542,6 +2552,18 @@
       tasks: [
         {
           id: "67C1DF1704EBF6AF",
+          type: "checkmark",
+        },
+      ],
+    },
+    {
+      x: 10.0,
+      y: 12.5,
+      invisible: true,
+      id: "78ADF668D8022DFE",
+      tasks: [
+        {
+          id: "037BF6F5A691E13B",
           type: "checkmark",
         },
       ],

--- a/config/ftbquests/quests/chapters/oritech.json5
+++ b/config/ftbquests/quests/chapters/oritech.json5
@@ -3,23 +3,16 @@
   group: "2B51AC12041E3F89",
   order_index: 7,
   icon: {
-    id: "ftbquests:missing_item",
+    id: "oritech:powered_furnace",
     count: 1,
-    components: {
-      "ftbquests:missing_item": "oritech:powered_furnace_block",
-    },
   },
   filename: "oritech",
-  always_invisible: true,
   default_quest_shape: "",
   default_hide_dependency_lines: false,
   quests: [
     {
       x: 0.5,
       y: 0.0,
-      dependencies: [
-        "4A19FA0912FE38B5",
-      ],
       size: 1.5,
       id: "0C9F9196CA49FF8D",
       tasks: [
@@ -30,7 +23,6 @@
             id: "alltheores:nickel_ingot",
             count: 1,
           },
-          count: 4,
         },
       ],
       rewards: [
@@ -46,7 +38,6 @@
       y: 2.0,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       id: "46EFCAE81C09368A",
       tasks: [
@@ -54,11 +45,8 @@
           id: "0C2A8E26354F19E7",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_1",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_1",
-            },
           },
         },
       ],
@@ -67,11 +55,8 @@
           id: "75D14A0CE2833E01",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_2",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_2",
-            },
           },
           count: 2,
         },
@@ -83,7 +68,6 @@
       dependencies: [
         "0C9F9196CA49FF8D",
         "58819CE09A648A43",
-        "4A19FA0912FE38B5",
       ],
       id: "6134991F25B25B42",
       tasks: [
@@ -91,11 +75,8 @@
           id: "1649E33D2C16EEEA",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:assembler",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:assembler_block",
-            },
           },
         },
       ],
@@ -104,11 +85,8 @@
           id: "283D277D4EB046D3",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:motor",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:motor",
-            },
           },
           count: 2,
         },
@@ -119,7 +97,6 @@
       y: 2.0,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       id: "58819CE09A648A43",
       tasks: [
@@ -127,25 +104,17 @@
           id: "6048DCF7257E5E54",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:magnetic_coil",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "2x oritech:magnetic_coil",
-            },
           },
-          count: 2,
         },
         {
           id: "1223FBE90DF34977",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:motor",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "2x oritech:motor",
-            },
           },
-          count: 2,
         },
       ],
       rewards: [
@@ -161,7 +130,6 @@
       y: 0.0,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       id: "418E0A23EC74F320",
       tasks: [
@@ -169,11 +137,8 @@
           id: "0A8553FC1355C9DF",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:centrifuge",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:centrifuge_block",
-            },
           },
         },
       ],
@@ -182,11 +147,8 @@
           id: "40199A609BBF0A82",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_speed_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_speed_addon",
-            },
           },
         },
       ],
@@ -196,7 +158,6 @@
       y: -2.0,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       id: "5F8363EC8F4499B6",
       tasks: [
@@ -204,24 +165,17 @@
           id: "0B2DF9C029068F9E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:foundry",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:foundry_block",
-            },
           },
         },
         {
           id: "7EBB366B3BA77459",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:adamant_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "4x oritech:adamant_ingot",
-            },
           },
-          count: 4,
         },
       ],
       rewards: [
@@ -229,11 +183,8 @@
           id: "64037A9F8CC649FF",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_2",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_2",
-            },
           },
         },
       ],
@@ -244,7 +195,6 @@
       dependencies: [
         "6134991F25B25B42",
         "5F8363EC8F4499B6",
-        "4A19FA0912FE38B5",
       ],
       id: "35BC118040E7428F",
       tasks: [
@@ -252,22 +202,16 @@
           id: "4FB60870492B65F4",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:enderic_laser",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:laser_arm_block",
-            },
           },
         },
         {
           id: "7A93D1F49CAABF0F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:target_designator",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:target_designator",
-            },
           },
         },
       ],
@@ -276,11 +220,8 @@
           id: "0933F9BA2E55D148",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:enderic_compound",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:enderic_compound",
-            },
           },
           count: 2,
         },
@@ -291,7 +232,6 @@
       y: 2.0,
       dependencies: [
         "35BC118040E7428F",
-        "4A19FA0912FE38B5",
       ],
       optional: true,
       id: "01C0DC225CB25A0C",
@@ -300,11 +240,8 @@
           id: "13A545DDFDC3D01B",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_hunter_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_hunter_addon",
-            },
           },
         },
       ],
@@ -314,7 +251,6 @@
       y: 0.0,
       dependencies: [
         "35BC118040E7428F",
-        "4A19FA0912FE38B5",
       ],
       id: "5189D72ED3808DC6",
       tasks: [
@@ -322,13 +258,9 @@
           id: "103CD887346D3D6C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:fluxite",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "4x oritech:fluxite",
-            },
           },
-          count: 4,
         },
       ],
     },
@@ -337,7 +269,6 @@
       y: -2.0,
       dependencies: [
         "6134991F25B25B42",
-        "4A19FA0912FE38B5",
       ],
       id: "1F139091C1B4E50B",
       tasks: [
@@ -345,11 +276,8 @@
           id: "7098540146A9649C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:processing_unit",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:processing_unit",
-            },
           },
         },
       ],
@@ -361,7 +289,6 @@
       dependencies: [
         "5189D72ED3808DC6",
         "1F139091C1B4E50B",
-        "4A19FA0912FE38B5",
       ],
       id: "7084E47579D62B52",
       tasks: [
@@ -369,11 +296,8 @@
           id: "3E688A8F21CFAAC7",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:flux_gate",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:flux_gate",
-            },
           },
         },
       ],
@@ -383,7 +307,6 @@
       y: -2.0,
       dependencies: [
         "418E0A23EC74F320",
-        "4A19FA0912FE38B5",
       ],
       id: "1B2BD489D5173B40",
       tasks: [
@@ -391,11 +314,8 @@
           id: "42CA9172BDF763D8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:enderic_compound",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:enderic_compound",
-            },
           },
         },
       ],
@@ -405,7 +325,6 @@
       y: -2.0,
       dependencies: [
         "5F8363EC8F4499B6",
-        "4A19FA0912FE38B5",
       ],
       id: "55DCCC4035B8BB2A",
       tasks: [
@@ -413,13 +332,9 @@
           id: "5BB2EA49C605295F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:duratium_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "8x oritech:duratium_ingot",
-            },
           },
-          count: 8,
         },
       ],
     },
@@ -430,7 +345,6 @@
         "55DCCC4035B8BB2A",
         "1B2BD489D5173B40",
         "7084E47579D62B52",
-        "4A19FA0912FE38B5",
       ],
       size: 1.5,
       id: "0EC0F93FA4B4BE49",
@@ -439,11 +353,8 @@
           id: "33CB89F0E05E9E82",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:atomic_forge",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:atomic_forge_block",
-            },
           },
         },
       ],
@@ -456,6 +367,7 @@
             count: 1,
             components: {
               "ftbquests:missing_item": "oritech:laser_arm_block",
+              "ftbquests:missing_item_count": 1,
             },
           },
         },
@@ -466,7 +378,6 @@
       y: -4.5,
       dependencies: [
         "6134991F25B25B42",
-        "4A19FA0912FE38B5",
       ],
       id: "3EB34CC8A3B0DB3C",
       tasks: [
@@ -474,13 +385,9 @@
           id: "0B06DB83A6814356",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:plutonium_pellet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "2x oritech:plutonium_pellet",
-            },
           },
-          count: 2,
         },
       ],
     },
@@ -489,7 +396,6 @@
       y: -6.5,
       dependencies: [
         "0EC0F93FA4B4BE49",
-        "4A19FA0912FE38B5",
       ],
       id: "290C1416EA2B5DF2",
       tasks: [
@@ -497,13 +403,9 @@
           id: "70BE0920B36053DD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:silicon_wafer",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "8x oritech:silicon_wafer",
-            },
           },
-          count: 8,
         },
       ],
     },
@@ -512,7 +414,6 @@
       y: -6.5,
       dependencies: [
         "290C1416EA2B5DF2",
-        "4A19FA0912FE38B5",
       ],
       id: "38F4448F9603FE68",
       tasks: [
@@ -520,13 +421,9 @@
           id: "71D17D7B86A67883",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:advanced_computing_engine",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "4x oritech:advanced_computing_engine",
-            },
           },
-          count: 4,
         },
       ],
     },
@@ -535,7 +432,6 @@
       y: -8.5,
       dependencies: [
         "38F4448F9603FE68",
-        "4A19FA0912FE38B5",
       ],
       id: "49D03933633D6A45",
       tasks: [
@@ -543,13 +439,9 @@
           id: "5FDE4FC13AA57195",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:super_ai_chip",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "2x oritech:super_ai_chip",
-            },
           },
-          count: 2,
         },
       ],
     },
@@ -558,7 +450,6 @@
       y: -8.5,
       dependencies: [
         "49D03933633D6A45",
-        "4A19FA0912FE38B5",
       ],
       id: "53880926982968FD",
       tasks: [
@@ -566,11 +457,8 @@
           id: "5B2A15126D3428CC",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:heisenberg_compensator",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:heisenberg_compensator",
-            },
           },
         },
       ],
@@ -589,7 +477,6 @@
       dependencies: [
         "3EB34CC8A3B0DB3C",
         "53880926982968FD",
-        "4A19FA0912FE38B5",
       ],
       size: 3.0,
       id: "1D9A00C81C2A97F0",
@@ -598,11 +485,8 @@
           id: "34DEEAC33FF9F789",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:manhattan_module",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:nuke",
-            },
           },
         },
       ],
@@ -619,7 +503,6 @@
       y: 3.5,
       dependencies: [
         "3FF39D583134AA8D",
-        "4A19FA0912FE38B5",
       ],
       id: "2A69272FD3C57924",
       tasks: [
@@ -627,11 +510,8 @@
           id: "253852CD4B706EFF",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_3",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_3",
-            },
           },
         },
       ],
@@ -648,7 +528,6 @@
       y: 3.5,
       dependencies: [
         "2A69272FD3C57924",
-        "4A19FA0912FE38B5",
       ],
       id: "4ED29ACF4A699E1B",
       tasks: [
@@ -656,11 +535,8 @@
           id: "508ABB1535506167",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_4",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_4",
-            },
           },
         },
       ],
@@ -677,7 +553,6 @@
       y: 3.5,
       dependencies: [
         "4ED29ACF4A699E1B",
-        "4A19FA0912FE38B5",
       ],
       id: "6EBFA16D212A7B22",
       tasks: [
@@ -685,11 +560,8 @@
           id: "442F4C00B01851D6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_5",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_5",
-            },
           },
         },
       ],
@@ -706,7 +578,6 @@
       y: 3.5,
       dependencies: [
         "6EBFA16D212A7B22",
-        "4A19FA0912FE38B5",
       ],
       id: "114EACA9B32B32FB",
       tasks: [
@@ -714,11 +585,8 @@
           id: "186E07C6072A5B9A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_6",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_6",
-            },
           },
         },
       ],
@@ -735,7 +603,6 @@
       y: 2.0,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       id: "334AB2ED426108C7",
       tasks: [
@@ -743,11 +610,8 @@
           id: "715EE42070D676F9",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:pulverizer",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:pulverizer_block",
-            },
           },
         },
       ],
@@ -756,11 +620,8 @@
           id: "706526C118BD9875",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:item_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:item_pipe",
-            },
           },
           count: 8,
         },
@@ -772,7 +633,6 @@
       dependencies: [
         "334AB2ED426108C7",
         "418E0A23EC74F320",
-        "4A19FA0912FE38B5",
       ],
       id: "724D8421684A5161",
       tasks: [
@@ -780,13 +640,9 @@
           id: "6AEA73B9168B5418",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:carbon_fibre_strands",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "4x oritech:carbon_fibre_strands",
-            },
           },
-          count: 4,
         },
       ],
     },
@@ -795,7 +651,6 @@
       y: 2.0,
       dependencies: [
         "334AB2ED426108C7",
-        "4A19FA0912FE38B5",
       ],
       id: "175509632CBF8631",
       tasks: [
@@ -803,11 +658,8 @@
           id: "10CCB4278890C456",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:fragment_forge",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:fragment_forge_block",
-            },
           },
         },
       ],
@@ -817,7 +669,6 @@
       y: 0.0,
       dependencies: [
         "418E0A23EC74F320",
-        "4A19FA0912FE38B5",
       ],
       id: "310FA9380CB3E0BB",
       tasks: [
@@ -825,11 +676,8 @@
           id: "7F9781231C101B36",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_fluid_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_fluid_addon",
-            },
           },
         },
       ],
@@ -840,7 +688,6 @@
       dependencies: [
         "175509632CBF8631",
         "310FA9380CB3E0BB",
-        "4A19FA0912FE38B5",
       ],
       id: "3DD27DED791C6A0B",
       tasks: [
@@ -869,7 +716,6 @@
       y: 2.0,
       dependencies: [
         "35BC118040E7428F",
-        "4A19FA0912FE38B5",
       ],
       id: "50243E5CF1B156ED",
       tasks: [
@@ -877,11 +723,8 @@
           id: "6CBC44DF8F1CD43F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:plutonium_dust",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:plutonium_dust",
-            },
           },
         },
       ],
@@ -890,11 +733,8 @@
           id: "08975132914D0D9B",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:plutonium_dust",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:plutonium_dust",
-            },
           },
           count: 2,
         },
@@ -906,7 +746,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "5E9AF8BB2C67DCCE",
@@ -915,45 +754,32 @@
           id: "5DD83D9863B3F913",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:fluid_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "6x oritech:fluid_pipe",
-            },
           },
-          count: 6,
         },
         {
           id: "2301E1897CA9A2F0",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:framed_fluid_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:framed_fluid_pipe",
-            },
           },
         },
         {
           id: "0B60CDC3D8179D01",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:fluid_pipe_duct",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:fluid_pipe_duct_block",
-            },
           },
         },
         {
           id: "6D77A2D3917BA181",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:portable_tank",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:small_tank_block",
-            },
           },
         },
       ],
@@ -962,11 +788,8 @@
           id: "463CA449BBF2E793",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:portable_tank",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:small_tank_block",
-            },
           },
         },
       ],
@@ -977,7 +800,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "7D2F41DD9774DDA7",
@@ -986,56 +808,40 @@
           id: "4060354A6129D860",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:item_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:item_pipe",
-            },
           },
-          count: 6,
         },
         {
           id: "6CAE1683AED7EE8E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:transparent_item_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:transparent_item_pipe",
-            },
           },
         },
         {
           id: "2F9E6878189829D8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:framed_item_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:framed_item_pipe",
-            },
           },
         },
         {
           id: "14F4DC1379595BFB",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:item_pipe_duct",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:item_pipe_duct_block",
-            },
           },
         },
         {
           id: "62737A2866FFA38E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:item_filter",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:item_filter_block",
-            },
           },
         },
       ],
@@ -1053,7 +859,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "208F759905CF7744",
@@ -1062,11 +867,8 @@
           id: "1B24996149004044",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:drone_port",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:drone_port_block",
-            },
           },
         },
       ],
@@ -1075,11 +877,8 @@
           id: "60ABD36C9F845E49",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:drone_port",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:drone_port_block",
-            },
           },
         },
       ],
@@ -1090,7 +889,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "53D5A6F210DF199C",
@@ -1099,33 +897,24 @@
           id: "1C8EED8F24EA5687",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:energy_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:energy_pipe",
-            },
           },
         },
         {
           id: "544B7591D272DFBA",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:framed_energy_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:framed_energy_pipe",
-            },
           },
         },
         {
           id: "305F7871112B7343",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:energy_pipe_duct",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:energy_pipe_duct_block",
-            },
           },
         },
       ],
@@ -1137,7 +926,6 @@
       hide_dependent_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "124CD4B8876B81F6",
@@ -1146,22 +934,16 @@
           id: "63A706B7E0157BFD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:portable_energy_storage",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:small_storage_block",
-            },
           },
         },
         {
           id: "01169BBCF825938C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:large_storage",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:large_storage_block",
-            },
           },
         },
       ],
@@ -1170,11 +952,8 @@
           id: "2BCB9CFF4FE8BB81",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_2",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_2",
-            },
           },
         },
       ],
@@ -1186,7 +965,6 @@
       hide_dependent_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "6539582429A70EE8",
@@ -1201,11 +979,8 @@
           id: "15A3A6A6C06B083B",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:energy_pipe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:energy_pipe",
-            },
           },
           count: 12,
         },
@@ -1218,7 +993,6 @@
       hide_dependent_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "7937DE650CABC1FF",
@@ -1227,11 +1001,8 @@
           id: "308FA84358A4F95A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:basic_generator",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:basic_generator_block",
-            },
           },
         },
       ],
@@ -1253,7 +1024,6 @@
       hide_dependent_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "161EDD68FF1A7F1B",
@@ -1262,11 +1032,8 @@
           id: "62345780F7357DBC",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:lava_generator",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:lava_generator_block",
-            },
           },
         },
       ],
@@ -1275,11 +1042,8 @@
           id: "3410FFC8CF3195AE",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:portable_tank",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:small_tank_block",
-            },
           },
         },
       ],
@@ -1291,7 +1055,6 @@
       hide_dependent_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "02315D55EB638E3C",
@@ -1300,11 +1063,8 @@
           id: "2881E93EFEBC8D9A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:bio_generator",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:bio_generator_block",
-            },
           },
         },
       ],
@@ -1313,11 +1073,8 @@
           id: "57CFF6D82D74D342",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:biomass",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:biomass",
-            },
           },
           count: 16,
         },
@@ -1330,7 +1087,6 @@
       hide_dependent_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "1630CFBFB562C43B",
@@ -1339,11 +1095,8 @@
           id: "6BEFA06E82E6693E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:fuel_generator",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:fuel_generator_block",
-            },
           },
         },
       ],
@@ -1355,7 +1108,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "24310BEACE75749D",
@@ -1371,7 +1123,6 @@
       y: -1.0,
       dependencies: [
         "24310BEACE75749D",
-        "4A19FA0912FE38B5",
       ],
       id: "70FAD4013FA8A14A",
       tasks: [
@@ -1379,11 +1130,8 @@
           id: "0C007608A88FD9BA",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_speed_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_speed_addon",
-            },
           },
         },
       ],
@@ -1393,7 +1141,6 @@
       y: 0.5,
       dependencies: [
         "24310BEACE75749D",
-        "4A19FA0912FE38B5",
       ],
       id: "1831B35A3239B583",
       tasks: [
@@ -1401,11 +1148,8 @@
           id: "246E8A4CA7C73532",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:auxiliary_processing_chamber_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_processing_addon",
-            },
           },
         },
       ],
@@ -1415,7 +1159,6 @@
       y: 2.0,
       dependencies: [
         "24310BEACE75749D",
-        "4A19FA0912FE38B5",
       ],
       id: "6FFD0301AC8C83ED",
       tasks: [
@@ -1423,11 +1166,8 @@
           id: "1BA40C54DCC57E13",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_efficiency_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_efficiency_addon",
-            },
           },
         },
       ],
@@ -1438,7 +1178,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "24310BEACE75749D",
-        "4A19FA0912FE38B5",
       ],
       id: "72E7AE66F2A7C4C4",
       tasks: [
@@ -1446,11 +1185,8 @@
           id: "75F88757B65D961A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_fluid_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_fluid_addon",
-            },
           },
         },
       ],
@@ -1461,7 +1197,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "24310BEACE75749D",
-        "4A19FA0912FE38B5",
       ],
       id: "11A4C57600E692EC",
       tasks: [
@@ -1469,11 +1204,8 @@
           id: "6CFFEB056A37AB86",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_capacitor_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_capacitor_addon",
-            },
           },
         },
       ],
@@ -1484,7 +1216,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "24310BEACE75749D",
-        "4A19FA0912FE38B5",
       ],
       id: "4CFA7EE8174E3FD8",
       tasks: [
@@ -1492,11 +1223,8 @@
           id: "37C428CDD7EF831D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_acceptor_addon",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_acceptor_addon",
-            },
           },
         },
       ],
@@ -1507,7 +1235,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "5932B5AD48F6AB74",
@@ -1516,11 +1243,8 @@
           id: "49D886A1F968B76A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:pipe_booster",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:pipe_booster_block",
-            },
           },
         },
       ],
@@ -1530,7 +1254,6 @@
       y: 0.5,
       dependencies: [
         "24310BEACE75749D",
-        "4A19FA0912FE38B5",
       ],
       size: 1.3,
       id: "7032AC2B9066CC39",
@@ -1539,11 +1262,8 @@
           id: "300FB736A05E5934",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_extender",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_extender",
-            },
           },
         },
       ],
@@ -1560,7 +1280,6 @@
       y: -1.5,
       dependencies: [
         "418E0A23EC74F320",
-        "4A19FA0912FE38B5",
       ],
       id: "1DBF1D4061518B0B",
       tasks: [
@@ -1575,7 +1294,6 @@
       y: -3.0,
       dependencies: [
         "1DBF1D4061518B0B",
-        "4A19FA0912FE38B5",
       ],
       id: "74AD63F738A5441F",
       tasks: [
@@ -1583,24 +1301,17 @@
           id: "6F10EB317EE4DEA9",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:refinery",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:refinery_block",
-            },
           },
         },
         {
           id: "2A48DB69DAF5DE76",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:refinery_chamber_module",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "2x oritech:refinery_module_block",
-            },
           },
-          count: 2,
         },
       ],
       rewards: [
@@ -1608,11 +1319,8 @@
           id: "3A8415E5B1790DCA",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:still_sheol_fire_bucket",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:still_sheol_fire_bucket",
-            },
           },
         },
       ],
@@ -1622,7 +1330,6 @@
       y: -4.5,
       dependencies: [
         "74AD63F738A5441F",
-        "4A19FA0912FE38B5",
       ],
       id: "4EAD06B0B3AD7D6E",
       tasks: [
@@ -1651,7 +1358,6 @@
       y: -6.0,
       dependencies: [
         "4EAD06B0B3AD7D6E",
-        "4A19FA0912FE38B5",
       ],
       id: "7CBAD1047B087803",
       tasks: [
@@ -1680,7 +1386,6 @@
       y: -8.0,
       dependencies: [
         "7CBAD1047B087803",
-        "4A19FA0912FE38B5",
       ],
       id: "4F89C04CEBF812F9",
       tasks: [
@@ -1711,7 +1416,6 @@
       hide_dependency_lines: true,
       dependencies: [
         "0C9F9196CA49FF8D",
-        "4A19FA0912FE38B5",
       ],
       size: 2.0,
       id: "4B5EBB46A1E58D53",
@@ -1720,11 +1424,8 @@
           id: "6A06EB448BDE885D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:nuclear_reactor_controller",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:reactor_controller",
-            },
           },
         },
       ],
@@ -1734,7 +1435,6 @@
       y: 3.5,
       dependencies: [
         "46EFCAE81C09368A",
-        "4A19FA0912FE38B5",
       ],
       id: "3FF39D583134AA8D",
       tasks: [
@@ -1742,24 +1442,9 @@
           id: "034A90108BCE7AB1",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "oritech:machine_core_2",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "oritech:machine_core_2",
-            },
           },
-        },
-      ],
-    },
-    {
-      x: -3.5,
-      y: -6.5,
-      invisible: true,
-      id: "4A19FA0912FE38B5",
-      tasks: [
-        {
-          id: "3AD2B84CDFD7F730",
-          type: "checkmark",
         },
       ],
     },
@@ -1774,7 +1459,7 @@
       height: 0.5,
       rotation: 0.0,
       image: "allthetweaks:item/atm_star",
-      id: "074B199D3C18B99B",
+      id: "545AA780308F4EAD",
     },
     {
       x: -5.5,
@@ -1782,8 +1467,8 @@
       width: 3.0,
       height: 3.0,
       rotation: 0.0,
-      image: "oritech:block/uranium_crystal",
-      id: "0FB587E8D3099308",
+      image: "oritech:block/uranite_crystal",
+      id: "4B7D2ECF908E2128",
     },
     {
       x: 0.0,
@@ -1792,7 +1477,7 @@
       height: 1.7,
       rotation: 0.0,
       image: "atm:textures/questpics/oritech/oritech-logo.png",
-      id: "5D688DCBC5C242EE",
+      id: "37230EAFFFB06908",
     },
     {
       x: -3.5,
@@ -1801,7 +1486,7 @@
       height: 1.5,
       rotation: 0.0,
       image: "allthemodium:item/atm_star",
-      id: "178A1E1E89A38D97",
+      id: "251505BCE51D3751",
     },
     {
       x: 11.0,
@@ -1810,7 +1495,7 @@
       height: 1.7,
       rotation: 0.0,
       image: "atm:textures/questpics/oritech/ori-logistics.png",
-      id: "67A3FF44F3FEBDC5",
+      id: "559E7C39FC364F3F",
     },
     {
       x: 11.0,
@@ -1819,7 +1504,7 @@
       height: 1.7,
       rotation: 0.0,
       image: "atm:textures/questpics/oritech/ori-energy.png",
-      id: "1E3F91D57BDDF548",
+      id: "179F63E908E1CDF1",
     },
     {
       x: 11.0,
@@ -1828,7 +1513,7 @@
       height: 1.7,
       rotation: 0.0,
       image: "atm:textures/questpics/oritech/ori-addons.png",
-      id: "351C635B410D87C0",
+      id: "090D60959B7086DB",
     },
   ],
 }

--- a/config/ftbquests/quests/chapters/productive_bees.json5
+++ b/config/ftbquests/quests/chapters/productive_bees.json5
@@ -39,10 +39,10 @@
           id: "4610119044965C5E",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "patchouli:guide_book",
             count: 1,
             components: {
-              "ftbquests:missing_item": "patchouli:guide_book",
+              "patchouli:book": "productivebees:guide",
             },
           },
         },
@@ -9002,11 +9002,8 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "silentgear:shield_blueprint",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "ars_elemental:glyph_bubble_shield",
-        },
       },
       x: 9.0,
       y: 4.5,
@@ -9037,10 +9034,155 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "silentgear:knife",
         count: 1,
         components: {
-          "ftbquests:missing_item": "the_bumblezone:essence_raging",
+          "silentgear:construction": {
+            parts: [
+              {
+                part: "silentgear:knife_blade",
+                item: {
+                  id: "silentgear:knife_blade",
+                  components: {
+                    "silentgear:material_list": [
+                      {
+                        material: "silentgear:redstone_alloy",
+                        item: {
+                          id: "enderio:redstone_alloy_ingot",
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+              {
+                part: "silentgear:rod",
+                item: {
+                  id: "silentgear:rod",
+                  components: {
+                    "silentgear:material_list": [
+                      {
+                        material: "silentgear:redstone_alloy",
+                        item: {
+                          id: "enderio:redstone_alloy_ingot",
+                        },
+                      },
+                      {
+                        material: "silentgear:redstone_alloy",
+                        item: {
+                          id: "enderio:redstone_alloy_ingot",
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+            example: false,
+            broken_count: 0,
+            repairedCount: 0,
+          },
+          "minecraft:item_name": {
+            translate: "item.silentgear.knife.nameProper",
+            with: [
+              {
+                translate: "material.silentgear.redstone_alloy",
+              },
+            ],
+          },
+          "silentgear:properties": {
+            "silentgear:traits": [
+              {
+                trait: "silentgear:malleable",
+                level: 5,
+                conditions: [
+                ],
+              },
+              {
+                trait: "silentgear:eroded",
+                level: 3,
+                conditions: [
+                  {
+                    gear_type: "silentgear:tool",
+                    type: "silentgear:gear_type",
+                  },
+                ],
+              },
+            ],
+            "silentgear:durability": 1050.0,
+            "silentgear:armor_durability": 20.0,
+            "silentgear:repair_efficiency": 2.0,
+            "silentgear:repair_value": 0.0,
+            "silentgear:enchantment_value": 18.0,
+            "silentgear:charging_value": 0.9,
+            "silentgear:rarity": 45.0,
+            "silentgear:harvest_tier": {
+              name: "iron",
+              level_hint: "2",
+              incorrect_blocks_for_tool: "minecraft:incorrect_for_iron_tool",
+            },
+            "silentgear:harvest_speed": 13.200001,
+            "silentgear:block_reach": 0.0,
+            "silentgear:attack_damage": 2.0,
+            "silentgear:attack_speed": 2.6000001,
+            "silentgear:attack_reach": 0.0,
+            "silentgear:swing_animation": {
+            },
+            "silentgear:kinetic_weapon": {
+              contact_cooldown_ticks: 0,
+              damage_multiplier: 0.0,
+            },
+            "silentgear:magic_damage": 4.0,
+          },
+          "minecraft:tool": {
+            rules: [
+              {
+                blocks: "#silentgear:sword_high_efficient",
+                speed: 15.0,
+                correct_for_drops: true,
+              },
+              {
+                blocks: "#minecraft:sword_instantly_mines",
+                speed: 3.4028235E38,
+              },
+              {
+                blocks: "#minecraft:sword_efficient",
+                speed: 1.5,
+              },
+            ],
+            damage_per_block: 2,
+            can_destroy_blocks_in_creative: false,
+          },
+          "minecraft:weapon": {
+          },
+          "minecraft:attribute_modifiers": [
+            {
+              type: "minecraft:block_interaction_range",
+              id: "silentgear:reach_modifier",
+              amount: 0.0,
+              operation: "add_value",
+              slot: "mainhand",
+            },
+            {
+              type: "minecraft:attack_damage",
+              id: "minecraft:base_attack_damage",
+              amount: 2.0,
+              operation: "add_value",
+              slot: "mainhand",
+            },
+            {
+              type: "minecraft:attack_speed",
+              id: "minecraft:base_attack_speed",
+              amount: -1.3999998569488525,
+              operation: "add_value",
+              slot: "mainhand",
+            },
+          ],
+          "minecraft:max_damage": 1050,
+          "minecraft:enchantable": {
+            value: 18,
+          },
+          "minecraft:rarity": "uncommon",
         },
       },
       x: 10.0,

--- a/config/ftbquests/quests/chapters/productive_trees.json5
+++ b/config/ftbquests/quests/chapters/productive_trees.json5
@@ -1,7 +1,7 @@
 {
   id: "1FAAEF0B9FD05CB9",
   group: "6614EE2378B8AFB9",
-  order_index: 5,
+  order_index: 6,
   icon: {
     id: "minecraft:oak_sapling",
     count: 1,
@@ -5511,10 +5511,10 @@
           id: "3A060AC1249E4D3A",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "patchouli:guide_book",
             count: 1,
             components: {
-              "ftbquests:missing_item": "patchouli:guide_book",
+              "patchouli:book": "productivetrees:guide",
             },
           },
         },

--- a/config/ftbquests/quests/chapters/pylons.json5
+++ b/config/ftbquests/quests/chapters/pylons.json5
@@ -1,7 +1,7 @@
 {
   id: "5712300EF4E5E846",
   group: "3D4E23B1100491AB",
-  order_index: 3,
+  order_index: 4,
   icon: {
     id: "pylons:infusion_pylon",
     count: 1,
@@ -9,7 +9,6 @@
   filename: "pylons",
   default_quest_shape: "",
   default_hide_dependency_lines: false,
-  progression_mode: "flexible",
   quests: [
     {
       x: 0.0,
@@ -214,7 +213,7 @@
       ],
     },
     {
-      x: 2.25,
+      x: 1.3499999999999999,
       y: 3.15,
       shape: "rsquare",
       size: 0.9,
@@ -319,6 +318,14 @@
             count: 1,
             components: {
               "ftbquests:missing_item": "minecraft:enchanted_book",
+              "ftbquests:missing_item_count": 1,
+              "ftbquests:missing_item_data": {
+                "minecraft:stored_enchantments": {
+                  levels: {
+                    "minecraft:unbreaking": 1,
+                  },
+                },
+              },
             },
           },
         },
@@ -379,18 +386,91 @@
         },
       ],
     },
+    {
+      x: 0.0,
+      y: 3.15,
+      shape: "rsquare",
+      size: 0.9,
+      id: "77B185799366ACD2",
+      tasks: [
+        {
+          id: "55A51CABCD9B2042",
+          type: "item",
+          item: {
+            id: "pylons:block_filter",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "7E2D3426904398C7",
+          type: "item",
+          item: {
+            id: "minecraft:honeycomb",
+            count: 1,
+          },
+          random_bonus: 1,
+        },
+        {
+          id: "67A917A78024E6E6",
+          type: "xp",
+          xp: 50,
+        },
+      ],
+    },
+    {
+      x: 0.0,
+      y: 2.0,
+      shape: "hexagon",
+      dependencies: [
+        "30B0240543253EFB",
+        "011F787E620DE9E8",
+        "77B185799366ACD2",
+      ],
+      dependency_requirement: "one_completed",
+      size: 1.2,
+      id: "2F5263A4166BFCD6",
+      tasks: [
+        {
+          id: "3AE982582C50FBF9",
+          type: "item",
+          item: {
+            id: "pylons:protection_pylon",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "15F3A7C65BDFB43F",
+          type: "item",
+          item: {
+            id: "minecraft:honeycomb",
+            count: 1,
+          },
+          count: 4,
+          random_bonus: 4,
+        },
+        {
+          id: "765C8669B005D78E",
+          type: "xp",
+          xp: 100,
+        },
+      ],
+    },
   ],
   quest_links: [
   ],
   images: [
     {
-      x: 0.0,
-      y: 3.0,
+      x: -5.0,
+      y: 4.0,
       width: 3.721698113207547,
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_harvester.png",
-      id: "1C816D383FC1C41B",
+      id: "68B0F3D3D1964848",
     },
     {
       x: -3.0,
@@ -399,7 +479,7 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_beacon.png",
-      id: "38982F8AED147DD2",
+      id: "20B23362CD13A833",
     },
     {
       x: 2.0,
@@ -408,7 +488,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_zombie.png",
-      id: "4D12280F7E137C0D",
+      id: "5190032FAE47EF8A",
     },
     {
       x: 3.5,
@@ -417,7 +497,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_skeleton.png",
-      id: "01F747E8ABB90C31",
+      id: "4691547DCC52BAA1",
     },
     {
       x: 5.0,
@@ -426,7 +506,7 @@
       height: 1.5,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_panda.png",
-      id: "2339FE6EAA440E56",
+      id: "7AC6D00070E45EA5",
     },
     {
       x: 0.0,
@@ -435,7 +515,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_title.png",
-      id: "7D6D58DC24DCEF06",
+      id: "10F91D1D941B898D",
     },
     {
       x: -3.0,
@@ -444,7 +524,7 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_no.png",
-      id: "1F092A95FB423742",
+      id: "7C8C4783D0E064C9",
     },
     {
       x: 2.0,
@@ -453,7 +533,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_no.png",
-      id: "0380BE98924074DF",
+      id: "4927597A8217C183",
     },
     {
       x: 3.5,
@@ -462,7 +542,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_no.png",
-      id: "2B9648ACC84B0FFA",
+      id: "0E9B62DAE6FC1CD5",
     },
     {
       x: 5.0,
@@ -471,7 +551,7 @@
       height: 1.6,
       rotation: 0.0,
       image: "atm:textures/questpics/pylons/pylon_no.png",
-      id: "41B0862CA4F5303B",
+      id: "1ECDE5312307B1F7",
     },
   ],
 }

--- a/config/ftbquests/quests/chapters/undergarden.json5
+++ b/config/ftbquests/quests/chapters/undergarden.json5
@@ -1,27 +1,20 @@
 {
   id: "65A95C2312976E49",
   group: "5A4775CCD6D26C80",
-  order_index: 6,
+  order_index: 7,
   icon: {
-    id: "ftbquests:missing_item",
+    id: "undergarden:catalyst",
     count: 1,
-    components: {
-      "ftbquests:missing_item": "undergarden:catalyst",
-    },
   },
   filename: "undergarden",
-  always_invisible: true,
   default_quest_shape: "",
   default_hide_dependency_lines: false,
   autofocus_id: "1C232674CD04024D",
   quests: [
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:goo_ball",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:goo_ball",
-        },
       },
       x: 2.0,
       y: -6.5,
@@ -29,7 +22,6 @@
       hide_dependent_lines: true,
       dependencies: [
         "6C4B93FE64BD418D",
-        "2F3B039EBAE58230",
       ],
       size: 3.0,
       id: "1C232674CD04024D",
@@ -50,18 +42,14 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:cracked_depthrock_bricks",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:cracked_depthrock_bricks",
-        },
       },
-      x: 13.5,
+      x: 14.0,
       y: -0.5,
       shape: "octagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.3,
       id: "00CB8D60E7831A57",
@@ -86,21 +74,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:grongle_sapling",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:grongle_sapling",
-        },
       },
       x: -5.5,
       y: -6.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "647A87E800C703C3",
+      tasks: [
+        {
+          id: "7C9EF32C628CA0A8",
+          type: "biome",
+          icon: {
+            id: "undergarden:grongle_sapling",
+            count: 1,
+          },
+          biome: "undergarden:gronglegrowth",
+        },
+      ],
       rewards: [
         {
           id: "2DBEE0D01E6A8995",
@@ -111,10 +106,9 @@
     },
     {
       x: -3.5,
-      y: -2.0,
+      y: -0.5,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "5FCA6F5FE97780B7",
@@ -123,11 +117,8 @@
           id: "442B73DD312E5D42",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:gronglet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:gronglet",
-            },
           },
         },
       ],
@@ -136,11 +127,8 @@
           id: "64525F6365C40773",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:gronglet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:gronglet",
-            },
           },
           count: 7,
         },
@@ -148,21 +136,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:glitterkelp",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:glitterkelp",
-        },
       },
       x: -5.5,
       y: -8.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "353AEEC116A5DEEF",
+      tasks: [
+        {
+          id: "518049B7B94DEA7A",
+          type: "biome",
+          icon: {
+            id: "undergarden:glitterkelp",
+            count: 1,
+          },
+          biome: "undergarden:ancient_sea",
+        },
+      ],
       rewards: [
         {
           id: "5429CC01B4971AD3",
@@ -177,7 +172,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "43A1BC20BB054A14",
       tasks: [
@@ -185,11 +179,8 @@
           id: "68A2E3EFD8C086B8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:glitterkelp",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:glitterkelp",
-            },
           },
         },
       ],
@@ -198,11 +189,8 @@
           id: "740845127F7ECC4D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:glitterkelp",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:glitterkelp",
-            },
           },
           count: 5,
         },
@@ -210,21 +198,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:wigglewood_sapling",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:wigglewood_sapling",
-        },
       },
       x: -2.0,
       y: -5.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "050D8480EE9D8E62",
+      tasks: [
+        {
+          id: "7FFA960B8F3CC151",
+          type: "biome",
+          icon: {
+            id: "undergarden:wigglewood_sapling",
+            count: 1,
+          },
+          biome: "undergarden:wigglewood_forest",
+        },
+      ],
       rewards: [
         {
           id: "6B757D1052B67B34",
@@ -235,21 +230,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:depthrock_bricks",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:depthrock_bricks",
-        },
       },
       x: -4.0,
       y: -7.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "4E3D548E5D8D7D26",
+      tasks: [
+        {
+          id: "12E13E7D8732BC65",
+          type: "biome",
+          icon: {
+            id: "undergarden:depthrock_bricks",
+            count: 1,
+          },
+          biome: "undergarden:forgotten_field",
+        },
+      ],
       rewards: [
         {
           id: "7E7389D366197863",
@@ -260,21 +262,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:veil_mushroom",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:veil_mushroom",
-        },
       },
       x: -3.0,
       y: -5.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "7E3DA4168D352B42",
+      tasks: [
+        {
+          id: "5F65CF932582E4D4",
+          type: "biome",
+          icon: {
+            id: "undergarden:veil_mushroom",
+            count: 1,
+          },
+          biome: "undergarden:veil_mushroom_bog",
+        },
+      ],
       rewards: [
         {
           id: "02C06AB42788957F",
@@ -284,11 +293,10 @@
       ],
     },
     {
-      x: 6.5,
+      x: 7.0,
       y: 1.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "24D38DA8E86DD897",
@@ -305,22 +313,18 @@
           id: "2BEA59F5963F6F21",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utheric_shard",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utheric_shard",
-            },
           },
           count: 3,
         },
       ],
     },
     {
-      x: 8.5,
+      x: 9.0,
       y: 1.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "380D3212D1CBA593",
@@ -337,22 +341,18 @@
           id: "1C3ABD092D7A3A57",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utheric_shard",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utheric_shard",
-            },
           },
           count: 6,
         },
       ],
     },
     {
-      x: 10.5,
+      x: 11.0,
       y: 1.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "70FD8856BFCD9AEE",
@@ -366,25 +366,21 @@
       ],
       rewards: [
         {
-          id: "1FFBDB345F444727",
+          id: "0DC33FE61C3E8A9D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utheric_cluster",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_crystal",
-            },
           },
           count: 3,
         },
       ],
     },
     {
-      x: 10.5,
+      x: 11.0,
       y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "5D229FA3A5F92954",
@@ -401,22 +397,18 @@
           id: "4F9BB0E1415EF299",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_nugget",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_nugget",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 2.0,
-      y: -0.5,
+      x: 0.5,
+      y: 1.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "4D836B9D9E3B898F",
@@ -433,11 +425,8 @@
           id: "1F234CCAC2D4F7D9",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:regalium_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:regalium_crystal",
-            },
           },
           count: 3,
         },
@@ -445,10 +434,9 @@
     },
     {
       x: 0.5,
-      y: -0.5,
+      y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "79C652E3FCB88550",
@@ -465,22 +453,18 @@
           id: "42738C69450F0A58",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:raw_gloomper_leg",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:raw_gloomper_leg",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 8.5,
+      x: 9.0,
       y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "0A1D6E233C0ECC8E",
@@ -502,10 +486,9 @@
     },
     {
       x: -2.5,
-      y: -0.5,
+      y: 1.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "4F3B4990BE6C2A4A",
@@ -522,22 +505,18 @@
           id: "21A9651456278BCD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:goo_ball",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:goo_ball",
-            },
           },
           count: 10,
         },
       ],
     },
     {
-      x: 6.5,
+      x: 7.0,
       y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "67A2347534269528",
@@ -558,11 +537,10 @@
       ],
     },
     {
-      x: -4.5,
-      y: -0.5,
+      x: -6.5,
+      y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "53FDC6C536E50A1A",
@@ -579,21 +557,17 @@
           id: "4FA496EDE0E9607C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:gwibling_bucket",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:gwibling_bucket",
-            },
           },
         },
       ],
     },
     {
-      x: 7.5,
+      x: 8.0,
       y: -0.5,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "71E1454990DEC451",
@@ -614,11 +588,10 @@
       ],
     },
     {
-      x: -3.5,
+      x: -4.5,
       y: 1.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "744DBE831C120B2F",
@@ -635,22 +608,18 @@
           id: "6FFDC804CABF16F8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:mogmoss",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:mogmoss",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: -5.5,
+      x: -6.5,
       y: 1.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "2E596B5A4EA2ABF4",
@@ -667,23 +636,19 @@
           id: "0DD7639423814FA5",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:blue_mogmoss",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:blue_mogmoss",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 9.5,
+      x: 10.0,
       y: -0.5,
       hide_dependent_lines: true,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "141681FE9E524FB0",
@@ -692,7 +657,7 @@
           id: "0D6A262F278C9399",
           type: "kill",
           entity: "undergarden:forgotten",
-          value: 3,
+          value: 1,
         },
       ],
       rewards: [
@@ -700,21 +665,17 @@
           id: "723172D86161488C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_battleaxe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_battleaxe",
-            },
           },
         },
       ],
     },
     {
-      x: 11.5,
+      x: 12.0,
       y: -0.5,
       dependencies: [
         "00CB8D60E7831A57",
-        "2F3B039EBAE58230",
       ],
       size: 1.9,
       id: "1054168AFD8520D4",
@@ -731,23 +692,20 @@
           id: "573A5DE60A3D35BF",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_ingot",
-            },
           },
           count: 2,
         },
       ],
     },
     {
-      x: 4.0,
+      x: 5.0,
       y: 5.5,
       shape: "diamond",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
+        "5AF0E903DB670D65",
       ],
       size: 1.5,
       id: "30582B5FBED35FD1",
@@ -756,11 +714,8 @@
           id: "05F86B23702AD630",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_crystal",
-            },
           },
         },
       ],
@@ -769,22 +724,18 @@
           id: "758D76C7755819CB",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_crystal",
-            },
           },
         },
       ],
     },
     {
-      x: 6.0,
+      x: 7.0,
       y: 5.5,
       shape: "diamond",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "3AF7446592D19FA6",
@@ -793,11 +744,8 @@
           id: "6C5AD33B8B69BEEC",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:regalium_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:regalium_crystal",
-            },
           },
         },
       ],
@@ -806,23 +754,19 @@
           id: "2ACBFB0DDEE3BF54",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:regalium_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:regalium_crystal",
-            },
           },
           count: 5,
         },
       ],
     },
     {
-      x: 2.0,
+      x: 1.0,
       y: 5.5,
       shape: "diamond",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "4F5A2E2A5C7F4837",
@@ -831,11 +775,8 @@
           id: "145F7277A6E82495",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_ingot",
-            },
           },
         },
       ],
@@ -844,22 +785,18 @@
           id: "228313ACC9720035",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_ingot",
-            },
           },
         },
       ],
     },
     {
-      x: 0.0,
+      x: -1.0,
       y: 5.5,
       shape: "diamond",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "51E2728C5E35A152",
@@ -868,11 +805,8 @@
           id: "2F2F12FD80DAE684",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_ingot",
-            },
           },
         },
       ],
@@ -881,23 +815,19 @@
           id: "74FC609432923CAE",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_ingot",
-            },
           },
           count: 2,
         },
       ],
     },
     {
-      x: -2.0,
+      x: -3.0,
       y: 5.5,
       shape: "diamond",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "4141EF8B8C316118",
@@ -906,11 +836,8 @@
           id: "030173D7AE2E8AF7",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_ingot",
-            },
           },
         },
       ],
@@ -919,23 +846,19 @@
           id: "58A82FCE900550AA",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_ingot",
-            },
           },
           count: 2,
         },
       ],
     },
     {
-      x: -2.0,
+      x: -3.0,
       y: 7.0,
       shape: "square",
       dependencies: [
         "4141EF8B8C316118",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "130577AD1A1A8222",
@@ -944,44 +867,32 @@
           id: "7F976851A2831B88",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_helmet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_helmet",
-            },
           },
         },
         {
           id: "560EBAD803282FF4",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_chestplate",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_chestplate",
-            },
           },
         },
         {
           id: "616F19EE1582B025",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_leggings",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_leggings",
-            },
           },
         },
         {
           id: "000C3B46CCF0F9C6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_boots",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_boots",
-            },
           },
         },
       ],
@@ -990,11 +901,71 @@
           id: "142964A7354A4C51",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_ingot",
-            },
+          },
+          count: 4,
+        },
+      ],
+    },
+    {
+      x: -3.5,
+      y: 4.0,
+      shape: "square",
+      dependencies: [
+        "4141EF8B8C316118",
+      ],
+      size: 1.15,
+      id: "16A04B2FC3F0D902",
+      tasks: [
+        {
+          id: "5383BF974E6E6A96",
+          type: "item",
+          item: {
+            id: "undergarden:cloggrum_pickaxe",
+            count: 1,
+          },
+        },
+        {
+          id: "4C1CB1CD27DE1996",
+          type: "item",
+          item: {
+            id: "undergarden:cloggrum_axe",
+            count: 1,
+          },
+        },
+        {
+          id: "3182842487B1ADC0",
+          type: "item",
+          item: {
+            id: "undergarden:cloggrum_shovel",
+            count: 1,
+          },
+        },
+        {
+          id: "3965E01BB5716714",
+          type: "item",
+          item: {
+            id: "undergarden:cloggrum_hoe",
+            count: 1,
+          },
+        },
+        {
+          id: "6C8D488FB86260B2",
+          type: "item",
+          item: {
+            id: "undergarden:cloggrum_sword",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "2D2BC753AF428A4B",
+          type: "item",
+          item: {
+            id: "undergarden:cloggrum_ingot",
+            count: 1,
           },
           count: 4,
         },
@@ -1006,89 +977,6 @@
       shape: "square",
       dependencies: [
         "4141EF8B8C316118",
-        "2F3B039EBAE58230",
-      ],
-      size: 1.15,
-      id: "16A04B2FC3F0D902",
-      tasks: [
-        {
-          id: "5383BF974E6E6A96",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_pickaxe",
-            },
-          },
-        },
-        {
-          id: "4C1CB1CD27DE1996",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_axe",
-            },
-          },
-        },
-        {
-          id: "3182842487B1ADC0",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_shovel",
-            },
-          },
-        },
-        {
-          id: "3965E01BB5716714",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_hoe",
-            },
-          },
-        },
-        {
-          id: "6C8D488FB86260B2",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_sword",
-            },
-          },
-        },
-      ],
-      rewards: [
-        {
-          id: "2D2BC753AF428A4B",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_ingot",
-            },
-          },
-          count: 4,
-        },
-      ],
-    },
-    {
-      x: -1.5,
-      y: 4.0,
-      shape: "square",
-      dependencies: [
-        "4141EF8B8C316118",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "1E81B903137BB62A",
@@ -1097,22 +985,16 @@
           id: "229BDF9C5EFF2F68",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_battleaxe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_battleaxe",
-            },
           },
         },
         {
           id: "6FBB26ACF48BF73F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_shield",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_shield",
-            },
           },
         },
       ],
@@ -1121,23 +1003,19 @@
           id: "13F796F5FD4B30A0",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:cloggrum_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:cloggrum_ingot",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 0.0,
+      x: -1.0,
       y: 7.0,
       shape: "square",
       dependencies: [
         "51E2728C5E35A152",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "7617737FC179EA1A",
@@ -1146,44 +1024,32 @@
           id: "1F56436CFE9E4829",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_helmet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_helmet",
-            },
           },
         },
         {
           id: "12D8CA0A44EF5EDD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_chestplate",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_chestplate",
-            },
           },
         },
         {
           id: "4F65FE9890B4283C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_leggings",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_leggings",
-            },
           },
         },
         {
           id: "75672283B8F0C3CB",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_boots",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_boots",
-            },
           },
         },
       ],
@@ -1192,23 +1058,19 @@
           id: "4CAED257664405F7",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_ingot",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 0.0,
+      x: -1.0,
       y: 4.0,
       shape: "square",
       dependencies: [
         "51E2728C5E35A152",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "46DCB235D3FEDA61",
@@ -1217,55 +1079,40 @@
           id: "3B2ECE1F852193F6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_sword",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_sword",
-            },
           },
         },
         {
           id: "51B4AD7164660ED5",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_pickaxe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_pickaxe",
-            },
           },
         },
         {
           id: "0D63C10C5B742431",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_axe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_axe",
-            },
           },
         },
         {
           id: "1A9A616D3CA79C35",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_shovel",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_shovel",
-            },
           },
         },
         {
           id: "20016A6E5AF25B3C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_hoe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_hoe",
-            },
           },
         },
       ],
@@ -1274,23 +1121,19 @@
           id: "3DA2915B3BB46AEC",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:froststeel_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:froststeel_ingot",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 4.0,
+      x: 5.0,
       y: 7.0,
       shape: "square",
       dependencies: [
         "30582B5FBED35FD1",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "01B13BBB41BBB460",
@@ -1299,44 +1142,32 @@
           id: "5C577BF2008DEA1C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_helmet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_helmet",
-            },
           },
         },
         {
           id: "4DC0DCE680549B36",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_chestplate",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_chestplate",
-            },
           },
         },
         {
           id: "0DBD340646246BCD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_leggings",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_leggings",
-            },
           },
         },
         {
           id: "192C931FBF39387C",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_boots",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_boots",
-            },
           },
         },
       ],
@@ -1345,23 +1176,19 @@
           id: "5B92118023C90ADD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_crystal",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 4.0,
+      x: 5.0,
       y: 4.0,
       shape: "square",
       dependencies: [
         "30582B5FBED35FD1",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "1FCF946B7BE3C0BD",
@@ -1370,55 +1197,40 @@
           id: "749B1D631FC31987",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_sword",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_sword",
-            },
           },
         },
         {
           id: "53F2440C55033418",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_pickaxe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_pickaxe",
-            },
           },
         },
         {
           id: "71B98C882B804619",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_axe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_axe",
-            },
           },
         },
         {
           id: "656B4889C4C1A4F0",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_shovel",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_shovel",
-            },
           },
         },
         {
           id: "4542D7CA0F4097B8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_hoe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_hoe",
-            },
           },
         },
       ],
@@ -1427,23 +1239,20 @@
           id: "024E32DD5FCCA5C8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:utherium_crystal",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:utherium_crystal",
-            },
           },
           count: 4,
         },
       ],
     },
     {
-      x: 2.5,
+      x: 1.5,
       y: 4.0,
       shape: "square",
+      hide_dependent_lines: true,
       dependencies: [
         "4F5A2E2A5C7F4837",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "6124C0E9E419694B",
@@ -1452,55 +1261,40 @@
           id: "2C7066FECE927691",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_pickaxe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_pickaxe",
-            },
           },
         },
         {
           id: "170BED42A6861142",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_axe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_axe",
-            },
           },
         },
         {
           id: "322FDB79D946CFC6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_shovel",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_shovel",
-            },
           },
         },
         {
           id: "0706A577127686BD",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_hoe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_hoe",
-            },
           },
         },
         {
           id: "08F28AD831730B2D",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_sword",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_sword",
-            },
           },
         },
       ],
@@ -1509,22 +1303,19 @@
           id: "5D5504B9CD6842AA",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_ingot",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_ingot",
-            },
           },
         },
       ],
     },
     {
-      x: 1.5,
+      x: 0.5,
       y: 4.0,
       shape: "square",
+      hide_dependent_lines: true,
       dependencies: [
         "4F5A2E2A5C7F4837",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "0D91A6B36BD2F526",
@@ -1533,11 +1324,8 @@
           id: "5E0BED0B76D91B6F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_battleaxe",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_battleaxe",
-            },
           },
         },
       ],
@@ -1551,18 +1339,16 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:forgotten_block",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:forgotten_block",
-        },
       },
-      x: -5.5,
+      x: -2.5,
       y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
+        "385A828C83812AFF",
       ],
+      hide_until_deps_complete: true,
       size: 1.5,
       id: "5B4B5C148D63ACA1",
       tasks: [
@@ -1574,11 +1360,15 @@
             count: 1,
             components: {
               "ftbquests:missing_item": "draconicevolution:mob_soul",
+              "ftbquests:missing_item_count": 1,
+              "ftbquests:missing_item_data": {
+                "draconicevolution:soul_id": "undergarden:minion",
+              },
             },
           },
           timer: 0,
           observation_type: "entity_type",
-          to_observe: "undergarden:minion",
+          to_observe: "undergarden:forgotten_minion",
         },
       ],
       rewards: [
@@ -1586,32 +1376,36 @@
           id: "1B3D9B39502EA161",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:forgotten_block",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:forgotten_block",
-            },
           },
         },
       ],
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:depthrock",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:depthrock",
-        },
       },
       x: -4.5,
       y: -8.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "36389696767EFB4E",
+      tasks: [
+        {
+          id: "7F8993963938570B",
+          type: "biome",
+          icon: {
+            id: "undergarden:depthrock",
+            count: 1,
+          },
+          biome: "undergarden:barren_abyss",
+        },
+      ],
       rewards: [
         {
           id: "4B4FBFCCB070EB30",
@@ -1622,21 +1416,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:blood_mushroom",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:blood_mushroom",
-        },
       },
       x: -3.5,
       y: -8.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "06D13E319C26C949",
+      tasks: [
+        {
+          id: "19FD2A6FBA7368C4",
+          type: "biome",
+          icon: {
+            id: "undergarden:blood_mushroom",
+            count: 1,
+          },
+          biome: "undergarden:blood_mushroom_bog",
+        },
+      ],
       rewards: [
         {
           id: "4A2FBB3EACE3F1BF",
@@ -1647,21 +1448,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:sediment",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:sediment",
-        },
       },
       x: -2.5,
       y: -8.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "1BAE1519E44E40CE",
+      tasks: [
+        {
+          id: "01BCE3270B3EEDA9",
+          type: "biome",
+          icon: {
+            id: "undergarden:sediment",
+            count: 1,
+          },
+          biome: "undergarden:dead_sea",
+        },
+      ],
       rewards: [
         {
           id: "0214A47335438F7E",
@@ -1672,21 +1480,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:deepturf_block",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:deepturf_block",
-        },
       },
       x: -5.0,
       y: -7.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "15A8F04BC10E619E",
+      tasks: [
+        {
+          id: "4AA288827E383289",
+          type: "biome",
+          icon: {
+            id: "undergarden:deepturf_block",
+            count: 1,
+          },
+          biome: "undergarden:dense_forest",
+        },
+      ],
       rewards: [
         {
           id: "12D1A6BD7DB7E1DE",
@@ -1705,10 +1520,20 @@
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "1E13D7CE5A9EFF74",
+      tasks: [
+        {
+          id: "38C521FBA84E18B7",
+          type: "biome",
+          icon: {
+            id: "minecraft:snow_block",
+            count: 1,
+          },
+          biome: "undergarden:frostfields",
+        },
+      ],
       rewards: [
         {
           id: "196AF64340C2D7B6",
@@ -1719,21 +1544,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:frozen_deepturf_block",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:frozen_deepturf_block",
-        },
       },
       x: -2.0,
       y: -7.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "0C98503A2F20484D",
+      tasks: [
+        {
+          id: "7425F62E6014D327",
+          type: "biome",
+          icon: {
+            id: "undergarden:frozen_deepturf_block",
+            count: 1,
+          },
+          biome: "undergarden:frosty_smogstem_forest",
+        },
+      ],
       rewards: [
         {
           id: "0957C1372A07536B",
@@ -1752,10 +1584,20 @@
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "073BA8470EA37A00",
+      tasks: [
+        {
+          id: "13998128201A3AD4",
+          type: "biome",
+          icon: {
+            id: "minecraft:packed_ice",
+            count: 1,
+          },
+          biome: "undergarden:icy_sea",
+        },
+      ],
       rewards: [
         {
           id: "603CBB78679E2DE9",
@@ -1766,21 +1608,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:indigo_mushroom",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:indigo_mushroom",
-        },
       },
       x: -3.5,
       y: -6.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "0A0A991BAC99092C",
+      tasks: [
+        {
+          id: "3CCDB2BDBD680158",
+          type: "biome",
+          icon: {
+            id: "undergarden:indigo_mushroom",
+            count: 1,
+          },
+          biome: "undergarden:indigo_mushroom_bog",
+        },
+      ],
       rewards: [
         {
           id: "6D3D8B1115168801",
@@ -1791,21 +1640,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:ink_mushroom",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:ink_mushroom",
-        },
       },
       x: -2.5,
       y: -6.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "278D34BBC13356DF",
+      tasks: [
+        {
+          id: "2489A0C2542332E1",
+          type: "biome",
+          icon: {
+            id: "undergarden:ink_mushroom",
+            count: 1,
+          },
+          biome: "undergarden:ink_mushroom_bog",
+        },
+      ],
       rewards: [
         {
           id: "404CE4FF92D35505",
@@ -1816,21 +1672,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:smog_vent",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:smog_vent",
-        },
       },
       x: -5.0,
       y: -5.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "511144EF336BFAF5",
+      tasks: [
+        {
+          id: "283BFDA10C3530EC",
+          type: "biome",
+          icon: {
+            id: "undergarden:smog_vent",
+            count: 1,
+          },
+          biome: "undergarden:smog_spires",
+        },
+      ],
       rewards: [
         {
           id: "5A53B26A5A61E77D",
@@ -1841,21 +1704,28 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "undergarden:smogstem_sapling",
         count: 1,
-        components: {
-          "ftbquests:missing_item": "undergarden:smogstem_sapling",
-        },
       },
       x: -4.0,
       y: -5.0,
       shape: "hexagon",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.2,
       id: "43FD4AEBB9548E57",
+      tasks: [
+        {
+          id: "44D8BAEAA4D0CA1D",
+          type: "biome",
+          icon: {
+            id: "undergarden:smogstem_sapling",
+            count: 1,
+          },
+          biome: "undergarden:smogstem_forest",
+        },
+      ],
       rewards: [
         {
           id: "4EA712B69725CCF4",
@@ -1870,7 +1740,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "51C59FDF0BD11FDF",
       tasks: [
@@ -1878,11 +1747,8 @@
           id: "15CC0FD07EFEBE55",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:wigglewood_sapling",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:wigglewood_sapling",
-            },
           },
         },
       ],
@@ -1891,11 +1757,8 @@
           id: "31C1359A8B0505E6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:wigglewood_sapling",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:wigglewood_sapling",
-            },
           },
           count: 3,
         },
@@ -1907,7 +1770,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "0FA77C28A57E06F1",
       tasks: [
@@ -1915,11 +1777,8 @@
           id: "608BB13CB5EC6DEE",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:veil_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:veil_mushroom",
-            },
           },
         },
       ],
@@ -1928,11 +1787,8 @@
           id: "732E86ED89DD1668",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:veil_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:veil_mushroom",
-            },
           },
           count: 5,
         },
@@ -1944,7 +1800,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "6D4FB6291CA8D1A6",
       tasks: [
@@ -1952,11 +1807,8 @@
           id: "1B783C6110983107",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:smogstem_sapling",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:smogstem_sapling",
-            },
           },
         },
       ],
@@ -1965,11 +1817,8 @@
           id: "0B39C06B1CD2C478",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:smogstem_sapling",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:smogstem_sapling",
-            },
           },
           count: 3,
         },
@@ -1981,7 +1830,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "6F416275B6F6D8F0",
       tasks: [
@@ -1989,11 +1837,8 @@
           id: "1E225EF7E2F75A22",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:blisterberry",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:blisterberry",
-            },
           },
         },
       ],
@@ -2002,11 +1847,8 @@
           id: "5E09B2842A2D24D4",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:blisterberry",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:blisterberry",
-            },
           },
           count: 8,
         },
@@ -2014,11 +1856,8 @@
           id: "02BE2A1B60B71380",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:rotten_blisterberry",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:rotten_blisterberry",
-            },
           },
           count: 3,
         },
@@ -2030,7 +1869,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "739601B0C43B239B",
       tasks: [
@@ -2038,11 +1876,8 @@
           id: "647B12D73B8AF0E8",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:ink_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:ink_mushroom",
-            },
           },
         },
       ],
@@ -2051,11 +1886,8 @@
           id: "6BAB81EDF4C8BDF3",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:ink_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:ink_mushroom",
-            },
           },
           count: 5,
         },
@@ -2067,7 +1899,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "4C5CFA45D9B4F6D3",
       tasks: [
@@ -2075,11 +1906,8 @@
           id: "576DEAD84C6D8E82",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:indigo_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:indigo_mushroom",
-            },
           },
         },
       ],
@@ -2088,11 +1916,8 @@
           id: "27ABA34900DB9865",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:indigo_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:indigo_mushroom",
-            },
           },
           count: 5,
         },
@@ -2104,7 +1929,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "2C5A7E4CD8B57E08",
       tasks: [
@@ -2112,11 +1936,8 @@
           id: "1B1CE8A91C2F9545",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:grongle_sapling",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:grongle_sapling",
-            },
           },
         },
       ],
@@ -2125,11 +1946,8 @@
           id: "492C35AF73FBB524",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:grongle_sapling",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:grongle_sapling",
-            },
           },
           count: 3,
         },
@@ -2137,11 +1955,8 @@
           id: "5637D555FCB587F6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:gronglet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:gronglet",
-            },
           },
         },
       ],
@@ -2152,7 +1967,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "22739522F0D33D7B",
       tasks: [
@@ -2160,11 +1974,8 @@
           id: "6E39966B6F48B054",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:gloomgourd",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:gloomgourd",
-            },
           },
         },
       ],
@@ -2173,11 +1984,8 @@
           id: "497894879AAB71AC",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:gloomgourd_seeds",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:gloomgourd_seeds",
-            },
           },
           count: 3,
         },
@@ -2189,7 +1997,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "08D9C809CF4062E8",
       tasks: [
@@ -2197,11 +2004,8 @@
           id: "5F64479B146297BE",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:underbeans",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:underbeans",
-            },
           },
         },
       ],
@@ -2210,11 +2014,8 @@
           id: "42D4474823033895",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:underbean_on_a_stick",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:underbean_on_a_stick",
-            },
           },
         },
       ],
@@ -2225,7 +2026,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "4568C2F465EDB960",
       tasks: [
@@ -2233,11 +2033,8 @@
           id: "192B3F4E4A36C0B6",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:droopvine_item",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:droopvine_item",
-            },
           },
         },
       ],
@@ -2246,24 +2043,20 @@
           id: "40EB047793AF98E2",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:droopvine_item",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:droopvine_item",
-            },
           },
           count: 10,
         },
       ],
     },
     {
-      x: 6.0,
+      x: 7.5,
       y: 7.0,
       shape: "square",
       dependencies: [
         "1C232674CD04024D",
         "141681FE9E524FB0",
-        "2F3B039EBAE58230",
       ],
       size: 1.15,
       id: "49EB9FB2133E3219",
@@ -2272,33 +2065,24 @@
           id: "7A0DABDDF01D5423",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:ancient_helmet",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:ancient_helmet",
-            },
           },
         },
         {
           id: "2C172CE16BBA49F2",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:ancient_chestplate",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:ancient_chestplate",
-            },
           },
         },
         {
           id: "29675CA8C6EACF13",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:ancient_leggings",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:ancient_leggings",
-            },
           },
         },
       ],
@@ -2313,9 +2097,6 @@
     {
       x: 2.0,
       y: -9.0,
-      dependencies: [
-        "2F3B039EBAE58230",
-      ],
       size: 1.5,
       id: "6C4B93FE64BD418D",
       tasks: [
@@ -2323,11 +2104,8 @@
           id: "6582E66B9320B94B",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:catalyst",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:catalyst",
-            },
           },
         },
       ],
@@ -2343,11 +2121,10 @@
       ],
     },
     {
-      x: -6.5,
-      y: -0.5,
+      x: -4.5,
+      y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "17C2C8F64B4AE6EE",
@@ -2364,11 +2141,8 @@
           id: "7E5EEF5DF0AC1106",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:raw_dweller_meat",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:raw_dweller_meat",
-            },
           },
           count: 5,
         },
@@ -2376,10 +2150,9 @@
     },
     {
       x: 3.5,
-      y: -0.5,
+      y: -2.0,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
       id: "119242549BD21764",
@@ -2396,51 +2169,10 @@
           id: "3DDBB04BC978ACB5",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:brute_tusk",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:brute_tusk",
-            },
           },
           count: 2,
-        },
-      ],
-    },
-    {
-      x: 5.5,
-      y: 4.0,
-      shape: "square",
-      dependencies: [
-        "1C232674CD04024D",
-        "2F3B039EBAE58230",
-      ],
-      size: 1.15,
-      id: "1190BB433EFA3945",
-      tasks: [
-        {
-          id: "5C5E12080C612D23",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:slingshot",
-            },
-          },
-        },
-      ],
-      rewards: [
-        {
-          id: "250BD4197B2AB64B",
-          type: "item",
-          item: {
-            id: "ftbquests:missing_item",
-            count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:rotten_blisterberry",
-            },
-          },
-          count: 5,
         },
       ],
     },
@@ -2450,7 +2182,37 @@
       shape: "square",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
+      ],
+      size: 1.15,
+      id: "1190BB433EFA3945",
+      tasks: [
+        {
+          id: "5C5E12080C612D23",
+          type: "item",
+          item: {
+            id: "undergarden:slingshot",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "250BD4197B2AB64B",
+          type: "item",
+          item: {
+            id: "undergarden:rotten_blisterberry",
+            count: 1,
+          },
+          count: 5,
+        },
+      ],
+    },
+    {
+      x: 7.5,
+      y: 4.0,
+      shape: "square",
+      dependencies: [
+        "1C232674CD04024D",
       ],
       size: 1.15,
       id: "5E63C78CDC44FF95",
@@ -2459,22 +2221,16 @@
           id: "245333BAF2116325",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:blisterbomb",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:blisterbomb",
-            },
           },
         },
         {
           id: "027921BB67B819C7",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:boomgourd",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:boomgourd",
-            },
           },
         },
       ],
@@ -2483,11 +2239,8 @@
           id: "47A34F25F9C3DE31",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:blisterbomb",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:blisterbomb",
-            },
           },
           count: 5,
         },
@@ -2499,7 +2252,6 @@
       shape: "rsquare",
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       id: "6751F2651063B3A5",
       tasks: [
@@ -2507,11 +2259,8 @@
           id: "6AB0706B07F12408",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:blood_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:blood_mushroom",
-            },
           },
         },
       ],
@@ -2520,11 +2269,8 @@
           id: "479B006B22A2A066",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:blood_mushroom",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:blood_mushroom",
-            },
           },
           count: 5,
         },
@@ -2533,9 +2279,6 @@
     {
       x: 0.5,
       y: -9.0,
-      dependencies: [
-        "2F3B039EBAE58230",
-      ],
       optional: true,
       invisible: true,
       id: "4C7E006502E30C20",
@@ -2552,24 +2295,26 @@
     },
     {
       icon: {
-        id: "ftbquests:missing_item",
+        id: "ftbquests:custom_icon",
         count: 1,
         components: {
-          "ftbquests:missing_item": "immersiveengineering:warning_sign_attention",
+          "ftbquests:icon": "fancymenu:textures/dialog/icons/warning.png",
         },
       },
       x: 2.0,
       y: -4.5,
       dependencies: [
         "1C232674CD04024D",
-        "2F3B039EBAE58230",
       ],
       size: 1.5,
+      progression_mode: "flexible",
       id: "76CDC18D7A208512",
       tasks: [
         {
-          id: "2116DA966E4C7711",
-          type: "checkmark",
+          id: "540ED00D536AF30C",
+          type: "advancement",
+          advancement: "undergarden:undergarden/contract_utheric_infection",
+          criterion: "",
         },
       ],
       rewards: [
@@ -2577,13 +2322,402 @@
           id: "775E4E9F9CCECE4F",
           type: "item",
           item: {
-            id: "ftbquests:missing_item",
+            id: "undergarden:rogdorium",
             count: 1,
-            components: {
-              "ftbquests:missing_item": "undergarden:rogdorium",
-            },
+          },
+        },
+      ],
+    },
+    {
+      x: 6.0,
+      y: -0.5,
+      dependencies: [
+        "1C232674CD04024D",
+      ],
+      size: 1.5,
+      id: "1D2C70F1750E84D0",
+      tasks: [
+        {
+          id: "6625CFA2BC3C79FC",
+          type: "kill",
+          entity: "undergarden:rotbelcher",
+          value: 1,
+        },
+      ],
+      rewards: [
+        {
+          id: "1B7CFC9AD46F299E",
+          type: "item",
+          item: {
+            id: "undergarden:utheric_shard",
+            count: 1,
+          },
+          count: 6,
+        },
+      ],
+    },
+    {
+      icon: {
+        id: "undergarden:dreadrock",
+        count: 1,
+      },
+      x: -1.5,
+      y: -8.0,
+      shape: "hexagon",
+      dependencies: [
+        "1C232674CD04024D",
+      ],
+      size: 1.2,
+      id: "6E7C8537D8A28833",
+      tasks: [
+        {
+          id: "333B84290E86737E",
+          type: "biome",
+          biome: "undergarden:depths",
+        },
+      ],
+      rewards: [
+        {
+          id: "7AAB33C55A30721A",
+          type: "xp_levels",
+          xp_levels: 1,
+        },
+      ],
+    },
+    {
+      x: 3.5,
+      y: 1.0,
+      dependencies: [
+        "1C232674CD04024D",
+      ],
+      size: 1.5,
+      id: "2A2041098C069772",
+      tasks: [
+        {
+          id: "038C0F9472D12EAC",
+          type: "kill",
+          entity: "undergarden:denizen",
+          value: 1,
+        },
+      ],
+      rewards: [
+        {
+          id: "27C33DB8D612F473",
+          type: "item",
+          item: {
+            id: "minecraft:wooden_axe",
+            count: 1,
+          },
+        },
+      ],
+    },
+    {
+      x: 2.0,
+      y: -0.5,
+      dependencies: [
+        "1C232674CD04024D",
+      ],
+      size: 1.5,
+      id: "1A23BBF444D17A63",
+      tasks: [
+        {
+          id: "4FC1F7CE88ED7629",
+          type: "kill",
+          entity: "undergarden:greater_dweller",
+          value: 1,
+        },
+      ],
+      rewards: [
+        {
+          id: "706B8AF3FDDDA55B",
+          type: "item",
+          item: {
+            id: "undergarden:dweller_steak",
+            count: 1,
+          },
+          count: 10,
+        },
+      ],
+    },
+    {
+      x: 2.5,
+      y: 7.0,
+      shape: "square",
+      dependencies: [
+        "257893DD23BF5017",
+      ],
+      size: 1.15,
+      id: "30ED5FF9DF7B34CF",
+      tasks: [
+        {
+          id: "13F612B90AD91226",
+          type: "item",
+          item: {
+            id: "undergarden:denizen_totem",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "4C846F6BFB27016E",
+          type: "item",
+          item: {
+            id: "undergarden:rogdoric_gronglet",
+            count: 1,
+          },
+        },
+      ],
+    },
+    {
+      x: 6.5,
+      y: 7.0,
+      shape: "square",
+      dependencies: [
+        "1C232674CD04024D",
+      ],
+      size: 1.15,
+      id: "30D6924003C6E273",
+      tasks: [
+        {
+          id: "4C98DF426C496E72",
+          type: "item",
+          item: {
+            id: "undergarden:denizen_mask",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "3DA6E4A511844644",
+          type: "xp_levels",
+          xp_levels: 2,
+        },
+      ],
+    },
+    {
+      icon: {
+        id: "undergarden:ancient_root",
+        count: 1,
+      },
+      x: -1.5,
+      y: -6.0,
+      shape: "hexagon",
+      dependencies: [
+        "1C232674CD04024D",
+      ],
+      size: 1.2,
+      id: "6F483B77D64F4EE2",
+      tasks: [
+        {
+          id: "7B279656A0D4D68E",
+          type: "biome",
+          biome: "undergarden:rogdorium_grove",
+        },
+      ],
+      rewards: [
+        {
+          id: "5DB84EAEA2A51F2D",
+          type: "xp_levels",
+          xp_levels: 1,
+        },
+      ],
+    },
+    {
+      icon: {
+        id: "undergarden:depthrock_pot",
+        count: 1,
+      },
+      x: -8.0,
+      y: -0.5,
+      shape: "octagon",
+      dependencies: [
+        "1C232674CD04024D",
+      ],
+      size: 1.3,
+      id: "75A66B81C1181F59",
+      tasks: [
+        {
+          id: "4E4D135972B50014",
+          type: "structure",
+          structure: "undergarden:forgotten_vestige",
+        },
+      ],
+      rewards: [
+        {
+          id: "7BC93E71591FD2BD",
+          type: "xp",
+          xp: 100,
+        },
+      ],
+    },
+    {
+      x: 3.0,
+      y: 5.5,
+      shape: "diamond",
+      dependencies: [
+        "6124C0E9E419694B",
+      ],
+      size: 1.5,
+      id: "257893DD23BF5017",
+      tasks: [
+        {
+          id: "572BBB367CBA8E6C",
+          type: "item",
+          item: {
+            id: "undergarden:rogdorium",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "277B2A40BA02A0F5",
+          type: "item",
+          item: {
+            id: "undergarden:rogdorium",
+            count: 1,
+          },
+          count: 3,
+        },
+      ],
+    },
+    {
+      x: 3.5,
+      y: 7.0,
+      shape: "square",
+      hide_dependent_lines: true,
+      dependencies: [
+        "257893DD23BF5017",
+      ],
+      size: 1.15,
+      id: "5AF0E903DB670D65",
+      tasks: [
+        {
+          id: "1062152C4646AA01",
+          type: "item",
+          item: {
+            id: "undergarden:infuser",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "3C0E126F60FBA918",
+          type: "item",
+          item: {
+            id: "undergarden:utheric_cluster",
+            count: 1,
+          },
+          count: 3,
+        },
+        {
+          id: "506F989F59BD54AD",
+          type: "item",
+          item: {
+            id: "undergarden:rogdorium",
+            count: 1,
+          },
+        },
+      ],
+    },
+    {
+      x: -5.5,
+      y: -0.5,
+      dependencies: [
+        "75A66B81C1181F59",
+      ],
+      size: 1.5,
+      id: "57545837046F552B",
+      tasks: [
+        {
+          id: "1D69C712BEC52F70",
+          type: "kill",
+          entity: "undergarden:mysterious_pot",
+          value: 1,
+        },
+      ],
+      rewards: [
+        {
+          id: "19D68195137BC47D",
+          type: "item",
+          item: {
+            id: "undergarden:cloggrum_nugget",
+            count: 1,
           },
           count: 4,
+        },
+        {
+          id: "55B5A2EB1C318AFA",
+          type: "item",
+          item: {
+            id: "undergarden:froststeel_nugget",
+            count: 1,
+          },
+          count: 3,
+        },
+      ],
+    },
+    {
+      x: 3.0,
+      y: 4.0,
+      shape: "square",
+      dependencies: [
+        "257893DD23BF5017",
+      ],
+      size: 1.15,
+      id: "19862DBCE9305DE3",
+      tasks: [
+        {
+          id: "2F75C879007B5D1C",
+          type: "item",
+          item: {
+            id: "undergarden:javelin",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "178E40488FD5F550",
+          type: "item",
+          item: {
+            id: "undergarden:rogdorium",
+            count: 1,
+          },
+        },
+      ],
+    },
+    {
+      x: 1.0,
+      y: 7.0,
+      shape: "square",
+      dependencies: [
+        "4F5A2E2A5C7F4837",
+      ],
+      size: 1.15,
+      id: "4985F82E0D300C6D",
+      tasks: [
+        {
+          id: "2CE8D497EDA2F7A1",
+          type: "item",
+          item: {
+            id: "undergarden:crumbling_catalyst",
+            count: 1,
+          },
+        },
+      ],
+      rewards: [
+        {
+          id: "728F52D655431E62",
+          type: "item",
+          item: {
+            id: "undergarden:forgotten_nugget",
+            count: 1,
+          },
+          count: 3,
         },
       ],
     },
@@ -2591,10 +2725,10 @@
       x: 3.5,
       y: -9.0,
       invisible: true,
-      id: "2F3B039EBAE58230",
+      id: "385A828C83812AFF",
       tasks: [
         {
-          id: "295EEC0FFA34E4A4",
+          id: "012CAA15ED32720A",
           type: "checkmark",
         },
       ],
@@ -2610,7 +2744,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_title.png",
-      id: "152AD9B04012E5FE",
+      id: "0FCFCC4623B3D4C0",
     },
     {
       x: 7.0,
@@ -2619,7 +2753,7 @@
       height: 1.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_vegetation.png",
-      id: "2372429BAD7F32A4",
+      id: "1195208D6D0C20B3",
     },
     {
       x: -4.0,
@@ -2628,16 +2762,16 @@
       height: 1.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_biomes.png",
-      id: "3A14372F0E8898EC",
+      id: "36831B0E1AD08A28",
     },
     {
       x: 2.0,
-      y: -3.0,
+      y: -3.5,
       width: 7.611940298507463,
       height: 1.5,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_neutral.png",
-      id: "25DC4E7AB5EA1E55",
+      id: "5379388A5F08BC33",
     },
     {
       x: 9.0,
@@ -2646,7 +2780,7 @@
       height: 1.5,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_hostile.png",
-      id: "3BC516ACA0C5FA8D",
+      id: "44D73E9FEF8A7524",
     },
     {
       x: -4.5,
@@ -2655,7 +2789,7 @@
       height: 1.5,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_friendly.png",
-      id: "257B94B3CC19CAC2",
+      id: "1C655087527569CA",
     },
     {
       x: 2.0,
@@ -2664,25 +2798,25 @@
       height: 1.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_tools.png",
-      id: "20E36D47D6AE80F4",
+      id: "000EE38F01F2FC4C",
     },
     {
-      x: -1.0,
+      x: 0.0,
       y: -0.5,
       width: 2.301980198019802,
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_gloomper.png",
-      id: "70FEF914CF604A1C",
+      id: "69E787AB3E2A7E7B",
     },
     {
-      x: 5.0,
+      x: 4.0,
       y: -0.5,
       width: 2.0,
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_brute.png",
-      id: "32166ABC28B8F12F",
+      id: "0545908329D7958F",
     },
     {
       x: 7.5,
@@ -2691,7 +2825,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_rotling.png",
-      id: "310734F2318AFAFA",
+      id: "3240DB40E444D78D",
     },
     {
       x: 9.0,
@@ -2700,7 +2834,7 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_rotwalker.png",
-      id: "1FF3AC57D4C9C5DF",
+      id: "78323EC099B91B71",
     },
     {
       x: 11.0,
@@ -2709,7 +2843,7 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_rotbeast.png",
-      id: "3E98474F89D53848",
+      id: "2CB79ABAF37D8F28",
     },
     {
       x: 13.0,
@@ -2718,7 +2852,7 @@
       height: 4.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_guardian.png",
-      id: "674EC57152E13499",
+      id: "7BB3773D6211601E",
     },
     {
       x: 12.5,
@@ -2727,7 +2861,7 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_muncher.png",
-      id: "0CF73EBC0D6BFEE9",
+      id: "24A4E2ACE65D19F9",
     },
     {
       x: 2.0,
@@ -2736,43 +2870,43 @@
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_stoneborn.png",
-      id: "1DBCD464AA21D09F",
+      id: "008731448BB51759",
     },
     {
-      x: -2.0,
-      y: 1.0,
+      x: -4.5,
+      y: 2.5,
       width: 1.5603112840466926,
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_mog.png",
-      id: "1623D0A85EA20CA6",
+      id: "15B63D153253691D",
     },
     {
-      x: -4.5,
+      x: -6.5,
       y: 2.5,
       width: 1.8461538461538463,
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_smog.png",
-      id: "2CF997DD613ABBF1",
+      id: "39B95FF0D6D1530D",
     },
     {
-      x: -7.5,
-      y: -2.0,
+      x: -9.5,
+      y: -0.5,
       width: 2.1219512195121952,
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_minion.png",
-      id: "3E408C51DE02153E",
+      id: "47A47562A5B278E0",
     },
     {
-      x: -7.5,
-      y: 1.5,
+      x: -8.5,
+      y: 1.0,
       width: 2.185185185185185,
       height: 2.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_gronglet.png",
-      id: "5D567A3AD1F20E6C",
+      id: "37E0386089FA972F",
     },
     {
       x: 12.5,
@@ -2781,7 +2915,7 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_grongle.png",
-      id: "05EC6C94EFD8EEFE",
+      id: "693EA811D77A28D6",
     },
     {
       x: -9.0,
@@ -2790,7 +2924,7 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_ink.png",
-      id: "1E101B10A937E5ED",
+      id: "3532BBDB1A88D88D",
     },
     {
       x: -9.0,
@@ -2799,7 +2933,7 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_veil.png",
-      id: "780D59DD7AF1E381",
+      id: "3AC32EB5230EB659",
     },
     {
       x: 12.5,
@@ -2808,26 +2942,25 @@
       height: 3.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_blood.png",
-      id: "35A39EFA1AF71E24",
+      id: "6AC7604D08EC6DE4",
     },
     {
-      x: -5.5,
+      x: -6.0,
       y: 6.0,
       width: 10.656,
       height: 6.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_background.png",
-      id: "2A6AA7D26325734C",
+      id: "7315DBD4ED2F7B60",
     },
     {
-      x: 10.0,
+      x: 10.5,
       y: 6.0,
       width: 10.656,
       height: 6.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_background.png",
-      corner: true,
-      id: "3E85A5D7E7EA7620",
+      id: "31EA9B08C07C09E8",
     },
     {
       x: -9.0,
@@ -2836,7 +2969,7 @@
       height: 4.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_vine.png",
-      id: "350A30A1A8AA1391",
+      id: "20FE082E31AA20B8",
     },
     {
       x: -9.0,
@@ -2845,7 +2978,7 @@
       height: 4.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_vine.png",
-      id: "6BFEB648A7821418",
+      id: "6B5624BF8E0335ED",
     },
     {
       x: 12.5,
@@ -2854,7 +2987,7 @@
       height: 4.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_vine.png",
-      id: "188BBE0276DB58EF",
+      id: "65681B1C9B481C72",
     },
     {
       x: 12.5,
@@ -2863,25 +2996,25 @@
       height: 4.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_vine.png",
-      id: "3EBAD7FD8E8A84A9",
+      id: "2B5230407338E631",
     },
     {
-      x: -9.5,
+      x: -10.0,
       y: 6.0,
       width: 10.656,
       height: 6.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_background.png",
-      id: "7FF18DBD983DE4A3",
+      id: "00ED7AB26782E751",
     },
     {
-      x: 14.0,
+      x: 14.5,
       y: 6.0,
       width: 10.656,
       height: 6.0,
       rotation: 0.0,
       image: "atm:textures/questpics/undergarden/undergarden_background.png",
-      id: "7E9A3655AE03B066",
+      id: "47D9976CC3364CA8",
     },
   ],
 }

--- a/config/ftbquests/quests/lang/en_us/chapters/apothic_enchanting.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/apothic_enchanting.json5
@@ -10,7 +10,7 @@
   "quest.79AF63E77AD70A93.title": "&2&lVanilla&r Max is just the start",
   "quest.24391162F4FF0587.title": "&bInfused Seashelf",
   "quest.3D31B94CC42BCE43.quest_desc": [
-    "The &8Tome of Extraction&r is the &8Tome&r we are looking for! It will take off all &5Enchantments&r and leave the Item alone!\\n\\nTo make it we'll need to &d&lInfuse&r our &8Tome of Superior Scrapping&r. \\n\\nWe can just use our previous &9Sculkshelf&r for this.",
+    "The &8Tome of Extraction&r is the &8Tome&r we are looking for! It will take off all &5Enchantments&r and leave the Item alone!\\n\\nTo make it we'll need to &d&lInfuse&r our &8Tome of Superior Scrapping&r. \\n\\nWe can just use our previous &9Sculkshelf&r setup for this.",
   ],
   "quest.0A3C464EF7CDD5F6.title": "&4Hellshelves",
   "quest.001A348054127235.quest_desc": [

--- a/config/ftbquests/quests/lang/en_us/chapters/occultism.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/occultism.json5
@@ -57,6 +57,8 @@
     "",
     "It's also used to create a couple of items that can speed up ritual making and performing by a significant amount.",
   ],
+  "task.037BF6F5A691E13B.title": "NOT HERE YET",
+  "task.51F520BF7DA37873.title": "Storage Stabilizers",
   "quest.57282D7E31EE61EE.title": "&aThe Otherworld Pickaxe&r",
   "quest.1DE0F289821F55D1.title": "&aChalking It Up",
   "quest.53DEA3DFEDC4809E.quest_subtitle": "Is it a Bird? Is it a Plane? No, it's an unbound &9Marid&r!",
@@ -89,6 +91,7 @@
     "",
     "&4WARNING: YOU MAY HAVE TO DO THIS ONE MULTIPLE TIMES TO GET ENOUGH DEMONIC MEAT.",
   ],
+  "task.4EDB733716D494CE.title": "Storage Actuators",
   "quest.2CF96A264EB5522C.quest_subtitle": "Maximum Infusion",
   "quest.2FD22502E6481269.title": "Trinity Gem",
   "quest.4DF0D7B85065ADC9.title": "Tools of the Trade: Butcher's Knife",
@@ -152,11 +155,7 @@
   "quest.4CE571F942461909.title": "Tools of the Trade: Artisanal Ritual Satchel",
   "quest.145C8235BCCB9BA8.title": "&cRed Chalk",
   "quest.690B89D23134B624.quest_desc": [
-    "Grab your chalks, draw your &dRonaza's Contact&r ritual, and get ready to create the ULTIMATE CHALK*!",
-    "",
-    "Instead of having to lug around a full set of 16 chalks, you can use the Rainbow Chalk to paint a color-changing Rune that counts as any of them!",
-    "",
-    "&8*Does not include Foundation Chalk. Make the Void Chalk to include those&r",
+    "Grab your chalks, draw your &dRonaza's Contact&r ritual, and get ready to create the ULTIMATE CHALK!\\n\\nInstead of having to lug around a full set of 16 chalks, you can use the Rainbow Chalk to paint a color-changing Rune that counts as any of them!",
   ],
   "task.1709A45C149125F1.title": "AllRightsReserved",
   "quest.56EC79AF11B0869E.quest_desc": [
@@ -164,6 +163,7 @@
   ],
   "quest.6FFFAE334DFAAAAB.title": "Iesnium Ritual Bowl",
   "quest.2960FFE0C53DFEB1.quest_subtitle": "The \"Even More Everything\" Ritual",
+  "task.1BBB313192F51FA8.title": "Storage Actuator Bases",
   "quest.7F09F8F98C13F11B.title": "Preparing for a Ritual: &6Bowls",
   "quest.0F412542271B6254.title": "Foreword on Pentacles",
   "quest.61999669BDE127F9.title": "Chalk Repair",
@@ -241,9 +241,7 @@
   "quest.29C83B00AC4AFC23.title": "What's Next?",
   "quest.39647A2473F6F7D7.quest_subtitle": "Put some Demon Dust™ on it!",
   "quest.54378277B8D28B1D.quest_desc": [
-    "An \"upgrade\" to the Rainbow Chalk, for those who don't like the rapid color-switching runes ruining their tediously crafted aesthetic. ",
-    "",
-    "Has the same function as the Rainbow Chalk, except all the runes will show up as white. Additionally, it works for foundation chalk as well.",
+    "An alternative to the Rainbow Chalk, for those who prefer the colors of Foundation Chalk.\\n\\nHas the same function as the Rainbow Chalk, except all the runes will cycle between Foundation Chalk colors.",
   ],
   "quest.42F50CE7FE715583.title": "&aUpgrading Our Magical Storage",
   "quest.4F35D04721DFC9FF.quest_desc": [
@@ -340,6 +338,7 @@
     "",
     "You'll also need the book to craft several things in the pack, so you kind of have to make it. :)",
   ],
+  "task.792FA8ED0719803C.title": "Stable Wormholes",
   "quest.5316DF321B45D2CA.title": "&dDreaming of &cDemons",
   "quest.6CC5FE34778F0DFA.quest_desc": [
     "You're bound to have too many items playing this modpack. It's just it works, and if you haven't figured out your storage situation yet, &dDimensional Storage&r might just be right for you!",
@@ -408,9 +407,7 @@
     "",
     "If you're worried about your Chalk breaking, but don't feel like doing the entire ritual to create a new chalk over again, then this ritual is for you!",
     "",
-    "Using the power of a &aDijinni&r, you can repair any color of Chalk to it's maximum!",
-    "",
-    "Alternatively, you could use something like the &aEternal Stella&r from the Forbidden Arcanus mod to permenantly preserve your Chalks!",
+    "Using the power of a &aDjinni&r, you can repair any color of Chalk to it's maximum!",
   ],
   "quest.42F50CE7FE715583.quest_desc": [
     "To upgrade the amount of stacks your magical storage can hold, you'll need to make &dStorage Stabilizers&r.",

--- a/config/ftbquests/quests/lang/en_us/chapters/pylons.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/pylons.json5
@@ -1,60 +1,49 @@
 {
   "quest.5C2C29ECA67F9B49.quest_subtitle": "Finally peace and quiet. ",
+  "quest.2F5263A4166BFCD6.quest_subtitle": "Accidental Destruction no more!",
+  "quest.77B185799366ACD2.quest_desc": [
+    "To set the Block Filter you just have to click the Block you want to prevent accidentally breaking, with the Block Filter. \\n\\nEach Filter can only hold 1 Block so if you want Beehives, Cables, Chests, Furnaces, and Brewing Stands to no longer be accidentally destroyed you'll need 5 Block Filters. \\n\\nYou can exchange the Block in it by simply clicking a different Block with it.",
+  ],
   "quest.5C2C29ECA67F9B49.quest_desc": [
-    "With the Lifeless Filter you will never have to worry about any Mob spawns within a 25x25 Chunk area. ",
-    "",
-    "This doesn't include Forced Spawns though, that is Mobs spawned from Spawners or even Spawn Eggs!",
-    "",
-    "The 25x25 will cover every distance Mobs spawn near the player. Hostile or Passive. ",
-    "",
-    "This includes every Y Level as well, above or below the Pylon, so no more worrying about lighting up caves! ",
-    "",
-    "There's no Whitelisting with this Filter, it will prevent every Mob Spawn.",
+    "With the Lifeless Filter you will never have to worry about any Mob spawns within a 25x25 Block area. \\n\\nThat's enough to cover every distance Mobs spawn near the player. Hostile or Passive. \\n\\nThis includes every Y Level as well, above or below the Pylon, so no more worrying about lighting up caves! \\n\\nThere's no Whitelisting with this Filter, it will prevent every Mob Spawn.",
   ],
   "quest.5B5FC539BD1F4A73.quest_desc": [
-    "This Pylon is all about blocking Mob Spawns. ",
-    "",
-    "You can use Mob Filters to block spawns of only certain Mobs or use the Lifeless Filter to block all Mob spawns! ",
-    "",
-    "You can stack multiple Mob Filters to block off more spawns. Plus you can change the Working Area for how far it blocks those Mob Spawns. ",
-    "",
-    "If you use the Lifeless Filter it will ignore all those settings.",
+    "This Pylon is all about blocking Mob Spawns. \\n\\nYou can use Mob Filters to block spawns of only certain Mobs or use the Lifeless Filter to block all Mob spawns! \\n\\nYou can stack multiple Mob Filters to block off more spawns. Plus you can change the Working Area for how far it blocks those Mob Spawns. \\n\\nIf you use the Lifeless Filter it will ignore all those settings.",
   ],
   "quest.011F787E620DE9E8.quest_desc": [
-    "To set the Mob Filter you just have to click the Mob you never want to see again, with the Mob Filter. \n\nEach Filter can only hold 1 Mob so if you want Zombies, Skeletons, Spiders, Creepers, and Endermen to no longer spawn you'll need 5 Mob Filters. \n\nYou can exchange the Mob in it by simplying clicking a different Mob with it.",
+    "To set the Mob Filter you just have to click the Mob you never want to see again, or prevent accidentally killing, with the Mob Filter. \\n\\nEach Filter can only hold 1 Mob so if you want Zombies, Skeletons, Spiders, Creepers, and Endermen to no longer spawn you'll need 5 Mob Filters. \\n\\nYou can exchange the Mob in it by simplying clicking a different Mob with it.",
   ],
   "quest.09D18512037386C1.quest_desc": [
-    "In order to put Potion Effects into you'll need to fill a Potion Filter. \n\nTo do so: have a Potion Effect on you, then right click with the Potion Filter to remove it from you and add it to the Filter, and repeat until it's filled and active. \n\nThis also works with modded Potion Effects or ones you can't usually get through Potions like Haste or Resistance.",
+    "In order to put Potion Effects into you'll need to fill a Potion Filter. \\n\\nTo do so: have a Potion Effect on you, then right click with the Potion Filter to remove it from you and add it to the Filter, and repeat until it's filled and active. \\n\\nThis also works with modded Potion Effects or ones you can't usually get through Potions like Haste or Resistance.",
   ],
   "quest.32E52AD6EF194A60.quest_desc": [
-    "The Expulsion Pylon works as a way of keeping people off your lawn. \n\nWhen placed down it will keep any Players who aren't whitelisted from a set amount of Chunks around it. \n\nThe Chunks are set in it's GUI in the top left from 1x1, 3x3, or 5x5 Chunks. \n\nAlso no it can't be set too close to Spawn. We know what you trolls want and we ain't giving it! \n\nTo Whitelist players check the Player Filter Quest!",
+    "The Expulsion Pylon works as a way of keeping people off your lawn. \\n\\nWhen placed down it will keep any Players who aren't whitelisted from a set amount of Chunks around it. \\n\\nThe Chunks are set in it's GUI in the top left from 1x1, 3x3, or 5x5 Chunks. \\n\\nAlso no it can't be set too close to Spawn. We know what you trolls want and we ain't giving it! \\n\\nTo Whitelist players check the Player Filter Quest!",
   ],
   "task.616C07AFBAFA7AE4.title": "Hoes",
   "quest.30B0240543253EFB.quest_desc": [
-    "Pylons is a wonderful mod made by our very own &aMutant Gumdrop&r!\n\nDon't let the size of the mod make you underestimate it! It provides many Pylons which can be used for many things to help make playing Minecraft easier.\n\nTo get started you'll need some Polished Blackstone to make them.",
+    "Pylons is a wonderful mod made by our very own &aMutant Gumdrop&r!\\n\\nDon't let the size of the mod make you underestimate it! It provides many Pylons which can be used for many things to help make playing Minecraft easier.\\n\\nTo get started you'll need some Polished Blackstone to make them.",
   ],
   "quest.034A9FBCA6D79BB6.quest_desc": [
-    "The Harvester Pylon needs a Hoe to work. \n\n(Hoes that can't break will work forever, Hoes that can will need to be replaced).",
+    "The Harvester Pylon needs a Hoe to work. \\n\\n(Hoes that can't break will work forever, Hoes that can will need to be replaced).",
   ],
   "quest.30B0240543253EFB.title": "&lPylons",
+  "quest.2F5263A4166BFCD6.quest_desc": [
+    "This Pylon prevents you from accidentally destroying certain Blocks/Mobs in the selected Chunk radius.\\n\\nYou can use a Mob Filter to prevent killing a certain Mob with the Pylon, or a Block Filter to prevent destroying a certain block.\\n\\nYou can stack multiple Mob and Block Filters to prevent multiple different Mobs/Blocks from being destroyed.",
+  ],
   "quest.18246A48C20B29D8.quest_desc": [
-    "The Infusion Pylon works similar as a Beacon just much better and cheaper! \nWhen a Potion Effect is put in by a Potion Filter, it will continuously give you the Potion Effect no matter where you are! \n\nYou heard me right, no longer is there a set radius for the Infusion Pylon, now it will reach you wherever.",
+    "The Infusion Pylon works similar as a Beacon just much better and cheaper! \\nWhen a Potion Effect is put in by a Potion Filter, it will continuously give you the Potion Effect while you're in the set Chunk area.",
   ],
   "task.59DD89698DBAA215.title": "AllRightsReserved",
   "quest.403F76908A8A5661.quest_desc": [
-    "The Explusion Pylon pushes players out of the area, but what if you want &lsome&r players nearby! Then you'll need a Player Filter. \n\nRight Click a Player with it to set them in it, and then put it into the Pylon to Whitelist them! \n\nSo when everyone else is pushed out, your friend won't be! \n\nAlso by default the Owner of the Pylon won't get expuled.",
+    "The Explusion Pylon pushes players out of the area, but what if you want &lsome&r players nearby! Then you'll need a Player Filter. \\n\\nRight Click a Player with it to set them in it, and then put it into the Pylon to Whitelist them! \\n\\nSo when everyone else is pushed out, your friend won't be! \\n\\nAlso by default the Owner of the Pylon won't get expuled.",
   ],
   "quest.12ED1EE85E146A4B.quest_desc": [
-    "Harvester Pylons work as a very simple Auto-Farm. Put the Pylon on or in the Water Source and it will automatically harvest and replant Crops that are fully grown in the set area around it. ",
-    "",
-    "The area can be set to 3x3, 5x5, 7x7, or 9x9 Blocks around the Pylon. ",
-    "",
-    "It will need a Hoe to use on the Plants and will need an Inventory like a chest above it to put the Crops. Do all that and if it's turned On it will start farming!",
+    "Harvester Pylons work as a very simple Auto-Farm. Put the Pylon on or in the Water Source and it will automatically harvest and replant Crops that are fully grown in the set area around it. \\n\\nThe area can be set to 3x3, 5x5, 7x7, or 9x9 Blocks around the Pylon. \\n\\nIt will need a Hoe to use on the Plants and will need an Inventory like a chest above it to put the Crops. Do all that and if it's turned On it will start farming!\\n\\n(Careful when using a lot of modifiers with it like Lilypads or fertilizer as when it goes very fast farming it can be a TPS eater).",
   ],
   "quest.32E52AD6EF194A60.quest_subtitle": "Get off my lawn!",
   "task.35320BB07FB39D05.title": "AllRightsReserved",
   "quest.011F787E620DE9E8.quest_subtitle": "He's uninvited!",
   "quest.5E02AE661945306C.quest_desc": [
-    "This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \n\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \n\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode.",
+    "This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks. \\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission. \\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode.",
   ],
 }

--- a/config/ftbquests/quests/lang/en_us/chapters/undergarden.json5
+++ b/config/ftbquests/quests/lang/en_us/chapters/undergarden.json5
@@ -1,108 +1,127 @@
 {
   "quest.00CB8D60E7831A57.quest_desc": [
-    "Catacombs are massive underground structures made of Depthrock Bricks. They might have a part sticking out of the ground you can find. \n\nWithin the huge maze lies &7Forgottens&r, hidden Chests, and the boss: &aForgotten Guardian&r. \n\nHope you're prepared for it!",
+    "Catacombs are massive underground structures made of Depthrock Bricks. They might have a part sticking out of the ground you can find. \\n\\nWithin the huge maze lies &7Forgottens&r, hidden Chests, and the boss: &aForgotten Guardian&r. \\n\\nHope you're prepared for it!",
   ],
+  "quest.1D2C70F1750E84D0.title": "&cRotbelcher",
+  "quest.6F483B77D64F4EE2.title": "Rogdorium Grove",
   "quest.353AEEC116A5DEEF.title": "Ancient Sea",
   "quest.4F3B4990BE6C2A4A.title": "&7Scintling&r",
   "quest.0C98503A2F20484D.quest_desc": [
-    "Near Frostfields you may find Frosty Smogstem Forests. \n\nThese are just like Frostfields just with Smogstem Trees!",
+    "Near Frostfields you may find Frosty Smogstem Forests. \\n\\nThese are just like Frostfields just with Smogstem Trees!",
     "{image:atm:textures/questpics/undergarden/undergarden_frostytrees.png width:200 height:100 align:center}",
   ],
   "quest.51C59FDF0BD11FDF.quest_desc": [
-    "I'm pretty sure the only definition of what a Wigglewood Tree is that it has Wigglewood Logs and Leaves. They seem to grow in any direction, size, and shape. \n\nYou can find them in Wigglewood Forests and Dense Forests. \n\nThey have pretty pink Leaves and brown Logs similar to Spruce!",
+    "I'm pretty sure the only definition of what a Wigglewood Tree is that it has Wigglewood Logs and Leaves. They seem to grow in any direction, size, and shape. \\n\\nYou can find them in Wigglewood Forests and Dense Forests. \\n\\nThey have pretty pink Leaves and brown Logs similar to Spruce!",
   ],
   "quest.0A1D6E233C0ECC8E.title": "&dNargoyle&r",
   "quest.6C4B93FE64BD418D.quest_subtitle": "Making the Portal",
+  "quest.1A23BBF444D17A63.title": "&2Greater Dweller",
+  "quest.19862DBCE9305DE3.title": "&3Javelin",
   "quest.6F416275B6F6D8F0.quest_desc": [
-    "Blisterberries spawn in Smog Spires. \n\nBecause they grow in such a disgusting area some will come Rotten. \n\nI don't recommend eating those, maybe they can be useful for something else!",
+    "Blisterberries spawn in Smog Spires. \\n\\nBecause they grow in such a disgusting area some will come Rotten. \\n\\nI don't recommend eating those, maybe they can be useful for something else!",
   ],
   "quest.073BA8470EA37A00.quest_desc": [
     "Another Sea, just this one is much colder.",
-    "{image:atm:textures/questpics/undergarden/undergarden_icey.png width:200 height:100 align:center}",
+    "{image:atm:textures/questpics/undergarden/undergarden_icy.png width:200 height:100 align:center}",
   ],
   "quest.050D8480EE9D8E62.title": "Wigglewood Forest",
   "quest.7617737FC179EA1A.title": "&bFroststeel&r Armor",
+  "quest.1A23BBF444D17A63.quest_desc": [
+    "&2Greater Dwellers&r spawn below Y Level 0. You'll need a &aForgotten Pickaxe&r or &6Allthemodium Pickaxe&r to Mine the Dreadrock in the way. \\n\\n&2Greater Dwellers&r have evolved differently from their lesser family members, the Depths are dangerous, they needed to become bigger and stronger! \\n\\nThey now have a bigger size with 100 Hearts. They will also be Neutral instead of Passive. Like Zombified Piglins, if one gets Hit, all will Attack.",
+    "{image:atm:textures/questpics/undergarden/undergarden_greater.png width:100 height:100 align:center}",
+  ],
   "quest.739601B0C43B239B.quest_desc": [
     "Yes they can make Black Dye!",
   ],
   "quest.6C4B93FE64BD418D.title": "The Undergarden",
   "quest.46DCB235D3FEDA61.quest_desc": [
-    "Similar to Iron Tools just all of these slow down whoever is hit by them. \n\nWell besides the Hoe, but do you really care about a simple hoe?",
+    "Similar to Iron Tools just all of these slow down whoever is hit by them. \\n\\nWell besides the Hoe, but do you really care about a simple hoe?",
   ],
   "quest.00CB8D60E7831A57.title": "Catacombs",
   "quest.53FDC6C536E50A1A.quest_desc": [
-    "&bGwiblings&r are friendly fish in the Seas. \n\nThey are smaller than &bGwibs&r and act like Vanilla Fish!",
+    "&bGwiblings&r are friendly fish in the Seas. \\n\\nThey are smaller than &bGwibs&r and act like &2&lVanilla&r Fish!",
   ],
   "quest.5E63C78CDC44FF95.quest_desc": [
-    "Rotten Blisterberries can't be thrown but when made into Blisterbombs they can be! \n\nYou can even go farther and make Boomgourds which will act like TNT that throws Blisterberries everywhere.",
+    "Rotten Blisterberries can't be thrown but when made into Blisterbombs they can be! \\n\\nYou can even go farther and make Boomgourds which will act like TNT that throws Blisterberries everywhere.",
   ],
   "quest.278D34BBC13356DF.title": "Ink Mushroom Bog",
+  "quest.75A66B81C1181F59.quest_desc": [
+    "Forgotten Vestiges are tiny ruins of Depthrock Bricks found within the &2&lUndergarden&r. \\n\\nHere are plenty of Pots full of Loot! \\n\\nJust break them!",
+  ],
   "quest.647A87E800C703C3.title": "Gronglegrowth",
   "quest.22739522F0D33D7B.quest_desc": [
-    "Gloomgourds spawn and farm like Pumpkins. \n\nAlso like Pumpkins they can be made into Pie or even Jack-O-Lanterns! \n\nUnlike Pumpkins they can be made into explosives...",
+    "Gloomgourds spawn and farm like Pumpkins. \\n\\nAlso like Pumpkins they can be made into Pie or even Jack-O-Lanterns! \\n\\nUnlike Pumpkins they can be made into explosives...",
   ],
   "quest.353AEEC116A5DEEF.quest_desc": [
-    "Ancient Seas are wide open Seas in the &2&lUndergarden&r. \n\nSomehow even with the amount of pollutants the Water is safe to drink. \n\nThe Water also holds &bGwibs&r and &bGwiblings&r. And can't forget Glitterkelp!",
+    "Ancient Seas are wide open Seas in the &2&lUndergarden&r. \\n\\nSomehow even with the amount of pollutants the Water is safe to drink. \\n\\nThe Water also holds &bGwibs&r and &bGwiblings&r. And can't forget Glitterkelp!",
     "{image:atm:textures/questpics/undergarden/undergarden_ancient.png width:200 height:100 align:center}",
   ],
   "quest.16A04B2FC3F0D902.title": "&7Cloggrum&r Tools",
   "quest.51E2728C5E35A152.quest_desc": [
-    "Froststeel spawns in the Frozen Biomes: Frostfields, Frosty Smogstem Forests, and probably Icey Seas. \n\nIt spawns in Shiverstone which replaces Depthrock in these Biomes. The Shiverstone will act similar to Ice as in it is slippery and slows you down a little. \n\nYou might also find some Nuggets in Munchers bellies!",
+    "Froststeel spawns in the Frozen Biomes: Frostfields, Frosty Smogstem Forests, and probably Icy Seas. \\n\\nIt spawns in Shiverstone which replaces Depthrock in these Biomes. The Shiverstone will act similar to Ice as in it is slippery and slows you down a little. \\n\\nYou might also find some Nuggets in Munchers bellies!",
+  ],
+  "quest.5AF0E903DB670D65.quest_desc": [
+    "With some Dreadrock, &3Rogdorium&r, and a &cUtheric Cluster&r, we can make the Infuser! \\n\\nThis is a Block we can use to Craft and Infuse certain Items. Right now there isn't too many Recipes but I bet we will see more! \\n\\nThe main usage will be to Craft &cUtheric Crystals&r and Infuse Armor with &3Rogdorium&r. \\n\\nIf Armor is Infused with &3Rogdorium&r, it will protect you from getting the &cRot&r disease. ",
   ],
   "quest.119242549BD21764.title": "&eBrutes&r",
   "quest.6124C0E9E419694B.title": "&aForgotten&r Tools",
   "quest.3AF7446592D19FA6.title": "&eRegalium&r",
   "quest.1BAE1519E44E40CE.quest_desc": [
-    "Picture the Ancient Sea. Okay now remove all Kelp from it and remove all &bGwibs&r and &bGwiblings&r. \n\nThat is the Dead Sea for you!",
+    "Picture the Ancient Sea. Okay now remove all Kelp from it and remove all &bGwibs&r and &bGwiblings&r. \\n\\nThat is the Dead Sea for you!",
     "{image:atm:textures/questpics/undergarden/undergarden_dead.png width:200 height:100 align:center}",
   ],
   "quest.06D13E319C26C949.title": "Blood Mushroom Bog",
   "quest.4F3B4990BE6C2A4A.quest_desc": [
-    "&7Scintlings&r are little innocent Slugs found everywhere in the &2&lUndergarden&r. \n\nThey act like Snow Golems as in they leave a trail wherever they walk. Just this one is more Gooey... \n\nOn death they drop Scintling Goo, but you can just farm it from their trails, so why kill them!",
+    "&7Scintlings&r are little innocent Slugs found everywhere in the &2&lUndergarden&r. \\n\\nThey act like Snow Golems as in they leave a trail wherever they walk. Just this one is more Gooey... \\n\\nOn death they drop Scintling Goo, but you can just farm it from their trails, so why kill them!",
     "{image:atm:textures/questpics/undergarden/undergarden_scintling.png width:150 height:100 align:center}",
   ],
   "quest.380D3212D1CBA593.title": "&cRotwalker&r",
+  "quest.1D2C70F1750E84D0.quest_desc": [
+    "A new &cRot&r Mob? \\n\\nThe &cRotbelcher&r has 17 and a half Hearts and 4 Armor Points. \\n\\nIf near you they will swing their Arms at you. If you are a little farther they will spit at you. \\n\\nThey need some mouthwash if their spit is that nasty.",
+    "{image:atm:textures/questpics/undergarden/undergarden_rotbelcher.png width:100 height:200 align:center}",
+  ],
   "quest.2E596B5A4EA2ABF4.quest_desc": [
-    "Is that Smogvent moving? No wait it's just a &3S'Mog&r! The close cousin of the &2Mog&r! \n\nThey act exactly like &2Mogs&r just these might drop Blue Mogmoss.",
+    "Is that Smogvent moving? No wait it's just a &3S'Mog&r! The close cousin of the &2Mog&r! \\n\\nThey act exactly like &2Mogs&r just these might drop Blue Mogmoss.",
     "{image:atm:textures/questpics/undergarden/undergarden_smog.png width:100 height:100 align:center}",
   ],
-  "quest.2F3B039EBAE58230.title": "NOT HERE YET",
+  "quest.57545837046F552B.title": "&2Mysterious Pots",
   "quest.3AF7446592D19FA6.quest_desc": [
-    "&eRegalium&r is the Emerald equivalent in &2&lUndergarden&r. \n\nIt can't be made into Armor or Tools but it can be used to trade with &2Stoneborns&r for other Items.",
+    "&eRegalium&r is the Emerald equivalent in &2&lUndergarden&r. \\n\\nIt can't be made into Armor or Tools but it can be used to trade with &2Stoneborns&r for other Items.",
   ],
   "quest.073BA8470EA37A00.title": "Icy Sea",
   "quest.0A0A991BAC99092C.quest_desc": [
-    "Indigo Mushroom Bog is much more filled Bog than the Blood Mushroom Bog. \n\nOf course it has Indigo Mushrooms but also Mini Smogstem Trees and ponds of Virulent Mix. I wonder what it does...",
+    "Indigo Mushroom Bog is much more filled Bog than the Blood Mushroom Bog. \\n\\nOf course it has Indigo Mushrooms but also Mini Smogstem Trees and ponds of Virulent Mix. I wonder what it does...",
     "{image:atm:textures/questpics/undergarden/undergarden_indigo.png width:200 height:100 align:center}",
   ],
   "quest.1C232674CD04024D.quest_desc": [
-    "The &2&lUndergarden&r Dimension is full of diverse and disgusting Biomes full of plenty of Vegetation, Mobs: friendly and unfriendly, and of course Ores and Items. \n\nHope you're ready for a fight!",
+    "The &2&lUndergarden&r Dimension is full of diverse and disgusting Biomes full of plenty of Vegetation, Mobs: friendly and unfriendly, and of course Ores and Items. \\n\\nHope you're ready for a fight!",
   ],
   "quest.6751F2651063B3A5.quest_desc": [
-    "Blood Mushrooms can be found within their Bogs. \n\nThey are shaped like Dark Oak Trees and are mostly White with only some blocks having Blood spots on them!",
+    "Blood Mushrooms can be found within their Bogs. \\n\\nThey are shaped like Dark Oak Trees and are mostly White with only some blocks having Blood spots on them!",
   ],
-  "quest.4D836B9D9E3B898F.title": "&2Stoneborn&r",
+  "quest.4D836B9D9E3B898F.title": "&aStoneborn&r",
   "quest.7E3DA4168D352B42.title": "Veil Mushroom Bog",
   "quest.01B13BBB41BBB460.quest_desc": [
-    "&cUtherium Armor&r has same stats as Netherite Armor! \n\nWithout needing a Smithing Template!",
+    "&cUtherium Armor&r has same stats as Netherite Armor! \\n\\nWithout needing a Smithing Template!",
   ],
   "quest.647A87E800C703C3.quest_desc": [
-    "My favorite Biome by far! \n\nA giant Green Jungle with huge Gronglegrowth Trees. \n\nOn those Trees you can find &eGronglets&r!",
+    "My favorite Biome by far! \\n\\nA giant Green Jungle with huge Gronglegrowth Trees. \\n\\nOn those Trees you can find &eGronglets&r!",
     "{image:atm:textures/questpics/undergarden/undergarden_grongle.png width:200 height:100 align:center}",
   ],
+  "task.012CAA15ED32720A.title": "NOT HERE YET",
   "quest.130577AD1A1A8222.title": "&7Cloggrum&r Armor",
-  "quest.744DBE831C120B2F.title": "&2Mog&r",
+  "quest.744DBE831C120B2F.title": "&aMog&r",
   "quest.1C232674CD04024D.title": "Welcome to the &2&lUndergarden&r!",
   "quest.08D9C809CF4062E8.quest_desc": [
-    "Eat em raw, roast them, put them on a Stick. \n\nWhat can't you do with Underbeans!",
+    "Eat em raw, roast them, put them on a Stick. \\n\\nWhat can't you do with Underbeans!",
   ],
   "quest.0A1D6E233C0ECC8E.quest_desc": [
-    "&dNargoyles&r are nasty and hostile Mobs that spawn underground. \n\nThey have 7 and a half Hearts and will relentlessly try to kill you. \n\nThey drop nothing and just serve as an obstacle for those trying to peacefully mine. ",
+    "&dNargoyles&r are nasty and hostile Mobs that spawn underground. \\n\\nThey have 7 and a half Hearts and will relentlessly try to kill you. \\n\\nThey drop nothing and just serve as an obstacle for those trying to peacefully mine. ",
     "{image:atm:textures/questpics/undergarden/undergarden_nargoyle.png width:100 height:100 align:center}",
   ],
   "quest.76CDC18D7A208512.title": "Warning",
   "quest.744DBE831C120B2F.quest_desc": [
-    "Is that rock moving? Oh wait that isn't a rock, it's a &2Mog&r! \n\n&2Mogs&r can be bred together with Depthrock Pebbles and on death might drop more Pebbles or Mogmoss! \n\nMogmoss can be used in many different recipes!",
+    "Is that rock moving? Oh wait that isn't a rock, it's a &aMog&r! \\n\\n&aMogs&r can be bred together with Depthrock Pebbles and on death might drop more Pebbles or Mogmoss! \\n\\nMogmoss can be used in many different recipes!",
     "{image:atm:textures/questpics/undergarden/undergarden_mog.png width:100 height:100 align:center}",
   ],
   "quest.0D91A6B36BD2F526.quest_desc": [
@@ -110,27 +129,31 @@
   ],
   "quest.30582B5FBED35FD1.title": "&cUtheric&r",
   "quest.511144EF336BFAF5.quest_desc": [
-    "The Smog Spires are... yep you guessed it! Where all the Smog comes from! Well not all, we can't discredit the &2Mogs&r and &3S'mogs&r. \n\nHere you will find Blisterberries, Coarse Deepsoil, and Smog Vents. I wouldn't recommend going near them though...",
+    "The Smog Spires are... yep you guessed it! Where all the Smog comes from! Well not all, we can't discredit the &2Mogs&r and &3S'mogs&r. \\n\\nHere you will find Blisterberries, Coarse Deepsoil, and Smog Vents. I wouldn't recommend going near them though...",
     "{image:atm:textures/questpics/undergarden/undergarden_smogspires.png width:200 height:100 align:center}",
   ],
   "quest.7E3DA4168D352B42.quest_desc": [
-    "I promise this is the last Mushroom Bog! \nThese Mushrooms look pretty normal, their gimmick though is what comes from them! \n\nThe Veils! Definitely a useful decoration Block.",
+    "I promise this is the last Mushroom Bog! \\nThese Mushrooms look pretty normal, their gimmick though is what comes from them! \\n\\nThe Veils! Definitely a useful decoration Block.",
     "{image:atm:textures/questpics/undergarden/undergarden_veil.png width:200 height:100 align:center}",
   ],
   "quest.511144EF336BFAF5.title": "Smog Spires",
   "quest.1E81B903137BB62A.quest_desc": [
-    "Normal Tools just won't suffice especially when handling the dangerous Mobs in the &2&lUndergarden&r. \n\nWe can craft the &7Cloggrum Shield&r which acts like a normal Shield. \n\nBut we will need to get the &7Battleaxe&r as a rare drop from &7Forgottens&r.",
+    "Normal Tools just won't suffice especially when handling the dangerous Mobs in the &2&lUndergarden&r. \\n\\nWe can craft the &7Cloggrum Shield&r which acts like a normal Shield. \\n\\nBut we will need to get the &7Battleaxe&r as a rare drop from &7Forgottens&r.",
   ],
   "quest.67A2347534269528.title": "&9Sploogie&r",
+  "quest.6E7C8537D8A28833.quest_desc": [
+    "Below Y Level 0 is two Biomes, the Depths is one. \\n\\nIn order to get below Y Level 0 you'll need to Mine Dreadrock. To Mine Dreadrock you will need a Forgotten Pickaxe or Allthemodium Pickaxe. \\n\\nHere Greater Dwellers, Denizens, and Rot Monsters will Spawn.",
+    "{image:atm:textures/questpics/undergarden/undergarden_depths.png width:200 height:100 align:center}",
+  ],
   "quest.76CDC18D7A208512.quest_desc": [
-    "In The &2&lUndergarden&r, &cRot Mobs&r can infect you with &cUtherium&r. In lower doses, this infection will decay over time. In high enough doses, it won't decay, and will have to be cured with &3Rogdorium&r, which is only found deep in the Dreadrock regions. You can either consume it, or infuse your armor with it to ward off this infection. I'll even give you some &3Rogdorium&r on the house!",
+    "In The &2&lUndergarden&r, &cRot Mobs&r: &cRotling&f, &cRotwalker&f, &cRotbelcher&f, and the &cRotbeast&r can infect you with &cUtherium&r. \\n\\nIt will show up as Red Bars above your Hunger Bars if you catch it. After 4 full Bars red lines will appear on your screen. At 8 Bars the Bars will start shaking to warn you it's getting worse. At 10 Bars all of them will glow and this is when you start taking Damage. \\n\\n&cRot&r will slowly go away on its own unless it is full. You can also get Purity from Mysterious Totems or Eat &3Rogdorium&r to get rid of it. \\n\\nBoth of these come from the Depths, which Spawn below Y Level 0. You'll need a &aForgotten Pickaxe&r or another Pickaxe of the same Tier like &6Allthemodium&r to reach it. \\n\\nThe only way to prevent the &cRot&r is by Infusing your Armor with &3Rogdorium&r using the Infuser.",
   ],
   "quest.5E63C78CDC44FF95.title": "Explosives!!!",
   "quest.6C4B93FE64BD418D.quest_desc": [
-    "Getting to the &2&lUndergarden&r is similar to getting to &c&lThe Nether&r. You'll need to craft a Portal. \n\nIt is the same shape and size as Nether Portals but instead of Obsidian you'll need a varient of Stone Bricks. Stone Bricks, Mossy Stone Bricks, or Deepslate Bricks. \n\nOnce formed, you can activate it by using the Catalyst on it. ",
+    "Getting to the &2&lUndergarden&r is similar to getting to &c&lThe Nether&r. You'll need to craft a Portal. \\n\\nIt is the same shape and size as Nether Portals but instead of Obsidian you'll need a varient of Stone Bricks. Stone Bricks, Mossy Stone Bricks, or Deepslate Bricks. \\n\\nOnce formed, you can activate it by using the Catalyst on it. ",
   ],
   "quest.43FD4AEBB9548E57.quest_desc": [
-    "Smogstem Forest is a neighboring Biome to Indigo Mushroom Bogs. \n\nOf course it is also Blue and has Indigo Mushrooms in it! Just has bigger Smogstem Trees!",
+    "Smogstem Forest is a neighboring Biome to Indigo Mushroom Bogs. \\n\\nOf course it is also Blue and has Indigo Mushrooms in it! Just has bigger Smogstem Trees!",
     "{image:atm:textures/questpics/undergarden/undergarden_smogstem.png width:200 height:100 align:center}",
   ],
   "quest.4141EF8B8C316118.title": "&7Cloggrum&r",
@@ -138,7 +161,7 @@
   "task.39194D9CDF673768.title": "AllRightsReserved",
   "quest.141681FE9E524FB0.title": "&7Forgotten&r",
   "quest.5D229FA3A5F92954.quest_desc": [
-    "&4Munchers&r are similar to any other Hostile Mobs in the &2&lUndergarden&r, but this ones drops makes it much more useful! \n\nThe Muncher can drop &7Cloggrum&r and &bFroststeel Nuggets&r on death.",
+    "&4Munchers&r are similar to any other Hostile Mobs in the &2&lUndergarden&r, but this ones drops makes it much more useful! \\n\\nThe Muncher can drop &7Cloggrum&r and &bFroststeel Nuggets&r on death.",
     "{image:atm:textures/questpics/undergarden/undergarden_muncher.png width:100 height:100 align:center}",
   ],
   "quest.53FDC6C536E50A1A.title": "&bGwibling&r",
@@ -146,158 +169,188 @@
   "quest.51E2728C5E35A152.title": "&bFroststeel&r",
   "quest.0C98503A2F20484D.title": "Frosty Smogstem Forest",
   "quest.6D4FB6291CA8D1A6.quest_desc": [
-    "Smogstem Trees are much thicker on their bottom halves, similar to Baobab Trees in real life! \n\nThey have Blue Leaves with Grey Logs. \nYou can find them in multiple Biomes: Smogstem Forests, Dense Forests, and even in Indigo Mushroom Bogs!",
+    "Smogstem Trees are much thicker on their bottom halves, similar to Baobab Trees in real life! \\n\\nThey have Blue Leaves with Grey Logs. \\nYou can find them in multiple Biomes: Smogstem Forests, Dense Forests, and even in Indigo Mushroom Bogs!",
   ],
   "quest.0A0A991BAC99092C.title": "Indigo Mushroom Bog",
   "quest.1BAE1519E44E40CE.title": "Dead Sea",
   "quest.2C5A7E4CD8B57E08.quest_desc": [
-    "Grongle Trees are tall Jungle like Trees that only spawn in Gronglegrowth Biomes! \n\nThese Trees are also where &eGronglets&r spawn on.",
+    "Grongle Trees are tall Jungle like Trees that only spawn in Gronglegrowth Biomes! \\n\\nThese Trees are also where &eGronglets&r spawn on.",
   ],
   "quest.4F5A2E2A5C7F4837.title": "&aForgotten&r",
   "quest.01B13BBB41BBB460.title": "&cUtherium&r Armor",
   "quest.5B4B5C148D63ACA1.title": "&aForgotten Minions&r",
   "quest.71E1454990DEC451.quest_desc": [
-    "&bGwibs&r are larger and angrier versions of &bGwiblings&r. \n\nThey don't have any Drops nor can they be placed in Buckets. All they offer is pain!",
+    "&bGwibs&r are larger and angrier versions of &bGwiblings&r. \\n\\nThey don't have any Drops nor can they be placed in Buckets. All they offer is pain!",
     "{image:atm:textures/questpics/undergarden/undergarden_gwib.png width:100 height:100 align:center}",
   ],
   "quest.4E3D548E5D8D7D26.title": "Forgotten Fields",
   "quest.49EB9FB2133E3219.quest_desc": [
-    "Ancient Armor is what's worn by &7Forgottens&r, and is where you can get it from. \n\nThere isn't any Ancient Boots though, apparently &7Forgottens&r don't have feet.",
+    "Ancient Armor is what's worn by &7Forgottens&r, and is where you can get it from. \\n\\nThere isn't any Ancient Boots though, apparently &7Forgottens&r don't have feet.",
   ],
   "quest.30582B5FBED35FD1.quest_desc": [
-    "&cUtherium&r can either be Mined or dropped from &cRot Mobs&r. ",
+    "&cUtheric Clusters&r and &cShards&r can be Dropped by multiple different Mobs, especially the &cRot&r Monsters. \\n\\n9 &cShards&r make 1 &cCluster&r. \\n\\nWe will then need to use an Infuser to combine &3Rogdorium&r and a &cUtheric Cluster&r to Craft &cUtheric Crystal&r.",
   ],
   "quest.79C652E3FCB88550.quest_desc": [
-    "&5Gloompers&r are technically Passive but they have a defense mechanism against you so I consider them Neutral! \n\nWhen hit they will drop an Effect similar to a Lingering Potion. \n\nOn death they will drop their Legs (which are very tasty) and possibly Leather. \n\nThey can also be bred with Gloomgourds!",
+    "&5Gloompers&r are technically Passive but they have a defense mechanism against you so I consider them Neutral! \\n\\nWhen hit they will drop an Effect similar to a Lingering Potion. \\n\\nOn death they will drop their Legs (which are very tasty) and possibly Leather. \\n\\nThey can also be bred with Gloomgourds!",
     "{image:atm:textures/questpics/undergarden/undergarden_gloomper.png width:100 height:100 align:center}",
   ],
   "quest.70FD8856BFCD9AEE.title": "&cRotbeast&r",
   "quest.70FD8856BFCD9AEE.quest_desc": [
-    "The largest and most dangerous &cRot Mob&r. \n\nThey have 80 Hearts, which I think qualifies as a Miniboss. \n\nLike all &cRot Mobs&r they will target &2Stoneborns&r and &7Forgottens&r and will drop &cUtheric Shards&r.",
+    "The largest and most dangerous &cRot Mob&r. \\n\\nThey have 80 Hearts, which I think qualifies as a Boss. \\n\\nLike all &cRot Mobs&r they will target &2Stoneborns&r and &7Forgottens&r and will drop &cUtheric Shards&r.",
     "{image:atm:textures/questpics/undergarden/undergarden_rotbeast.png width:100 height:100 align:center}",
   ],
   "quest.46DCB235D3FEDA61.title": "&bFroststeel&r Tools",
   "quest.4141EF8B8C316118.quest_desc": [
-    "&7Cloggrum&r is the Iron of the &2&lUndergarden&r. \n\nIt is found everywhere and is used in a dozen different recipes. \n\nHeck even some Mobs drop it!",
+    "&7Cloggrum&r is the Iron of the &2&lUndergarden&r. \\n\\nIt is found everywhere and is used in a dozen different recipes. \\n\\nHeck even some Mobs drop it!",
   ],
   "quest.5B4B5C148D63ACA1.quest_desc": [
-    "&aForgotten Minions&r aren't spawned like normal Mobs, they need to be created. They are created by placing a Carved Gloomgourd over a &aBlock of Forgotten Ingots&r. \n\nThey act similar to Snow Golems, they won't ever attack you and instead shoot at Hostile Mobs. \n\nThey have 10 Hearts and don't drop anything on death... but like why would you kill them?",
+    "&aForgotten Minions&r aren't spawned like normal Mobs, they need to be created. They are created by placing a Carved Gloomgourd over a &aBlock of Forgotten Ingots&r. \\n\\nThey act similar to Snow Golems, they won't ever attack you and instead shoot at Hostile Mobs. \\n\\nThey have 10 Hearts and don't drop anything on death... but like why would you kill them?",
     "{image:atm:textures/questpics/undergarden/undergarden_minion.png width:125 height:100 align:center}",
   ],
+  "quest.2A2041098C069772.title": "&7Denizen",
   "quest.6124C0E9E419694B.quest_desc": [
-    "Upgrade &7Cloggrum&r Tools with &aForgotten Ingots&r and a Smithing Template. \n\nThese are the best Tools you can get, they come with Efficiency on them already just for &2&lUndergarden&r Blocks. \n\nAnd the Sword and Axe will deal more damage to all &2&lUndergarden&r Mobs but the &cRot Beast&r and &aForgotten Guardian&r!",
+    "Upgrade &7Cloggrum&r Tools with &aForgotten Ingots&r and a Smithing Template. \\n\\nThese are the best Tools you can get, they come with Efficiency on them already just for &2&lUndergarden&r Blocks. \\n\\nAnd the Sword and Axe will deal more damage to all &2&lUndergarden&r Mobs but the &cRot Beast&r and &aForgotten Guardian&r!",
+  ],
+  "quest.57545837046F552B.quest_desc": [
+    "Wait that's not a normal Pot! \\n\\n&2Mysterious Pots&r are living creatures who disguise themselves as Pots. \\n\\nThey have 4 Hearts and will run from you when Hit. If they think they are safe from you they will return to their disguise. \\n\\nOn Death they can Drop &7Cloggrum&r and &bFroststeel Nuggets&r and &cUtheric Shards&r. ",
+    "{image:atm:textures/questpics/undergarden/undergarden_pot.png width:100 height:120 align:center}",
+  ],
+  "quest.257893DD23BF5017.quest_desc": [
+    "To get &3Rogdorium&r we'll need to visit the Depths beneath Y Level 0. For that you'll need a &aForgotten Pickaxe&r or &6Allthemodium Pickaxe&r. \\n\\nYou'll also need the same Tier Pickaxe to Mine &3Rogdorium Ore&r. This Spawns anywhere in the Depths. \\n\\nYou can also use a &aForgotten&r or &6Allthemodium Axe&r to Mine &3Rogdoric Ancient Root&r. These are much more common but will only give a &3Rogdorium Nugget&r compared to the full version the &3Ore&r gives.",
   ],
   "quest.79C652E3FCB88550.title": "&5Gloomper&r",
   "quest.5FCA6F5FE97780B7.quest_desc": [
-    "&eGronglets&r are technically Blocks not Mobs. But I love them too much to not include them! \n\nThey spawn on Grongle Trees and emit Noise and Light! Definitely perfect for decoration.",
+    "&eGronglets&r are technically Blocks not Mobs. But I love them too much to not include them! \\n\\nThey spawn on Grongle Trees and emit Noise and Light! Definitely perfect for decoration.",
     "{image:atm:textures/questpics/undergarden/undergarden_gronglet.png width:100 height:100 align:center}",
   ],
   "quest.5FCA6F5FE97780B7.title": "&eGronglets&r",
   "quest.050D8480EE9D8E62.quest_desc": [
-    "Wigglewood Forests are forests like all others. \n\nJust these Trees like to go as they please.",
+    "Wigglewood Forests are forests like all others. \\n\\nJust these Trees like to go as they please.",
     "{image:atm:textures/questpics/undergarden/undergarden_wiggle.png width:200 height:100 align:center}",
+  ],
+  "quest.6F483B77D64F4EE2.quest_desc": [
+    "Below Y Level 0 is two Biomes, the Rogdorium Grove is one. \\n\\nIn order to get below Y Level 0 you'll need to Mine Dreadrock. To Mine Dreadrock you will need a Forgotten Pickaxe or Allthemodium Pickaxe. \\n\\nA much nicer Biome compared to the Depths. A lot less Monsters and a lot more plant life! Now with Smogstem Trees and plenty of Flowers.",
+    "{image:atm:textures/questpics/undergarden/undergarden_rogdorium.png width:200 height:100 align:center}",
   ],
   "quest.15A8F04BC10E619E.title": "Dense Forest",
   "quest.24D38DA8E86DD897.quest_desc": [
-    "The smallest and weakest of the &cRot Mobs&r. \n\nThese have 5 Hearts. \n\nLike all &cRot Mobs&r they will target &2Stoneborns&r and &7Forgottens&r and will drop &cUtheric Shards&r.",
+    "The smallest and weakest of the &cRot Mobs&r. \\n\\nThese have 5 Hearts. \\n\\nLike all &cRot Mobs&r they will target &2Stoneborns&r and &7Forgottens&r and will drop &cUtheric Shards&r.",
     "{image:atm:textures/questpics/undergarden/undergarden_rotling.png width:100 height:100 align:center}",
   ],
   "quest.4568C2F465EDB960.quest_desc": [
-    "Droopfruit can spawn pretty much in any Biome just look up! \n\nThey spawn on the roof of most Biomes and will grow similar to Glowberries.",
+    "Droopfruit can spawn pretty much in any Biome just look up! \\n\\nThey spawn on the roof of most Biomes and will grow similar to Glowberries.",
   ],
   "quest.1190BB433EFA3945.quest_desc": [
-    "Slingshot is a very fun weapon added by &2&lUndergarden&r. It has 4 Ammo that can be shot: \n\nScintling Goo can be fired and when it hits a Mob it'll give them the Gooey Effect. \n\nDepthrocks are just normal projectiles. \n\nRotten Blisterberries will blow up on impact. \n\nAnd &eGronglets&r don't do any damage they just make noise and get shot!",
+    "Slingshot is a very fun weapon added by &2&lUndergarden&r. It has 4 Ammo that can be shot: \\n\\nScintling Goo can be fired and when it hits a Mob it'll give them the Gooey Effect. \\n\\nDepthrocks are just normal projectiles. \\n\\nRotten Blisterberries will blow up on impact. \\n\\nAnd &eGronglets&r don't do any damage they just make noise and get shot!",
   ],
   "quest.36389696767EFB4E.quest_desc": [
-    "The Barren Abyss is as the name suggests, barren... It holds nothing but Hostile Mobs and Pebbles. \n\nPersonally I'd rather find Pebbles anywhere else...",
+    "The Barren Abyss is as the name suggests, barren... It holds nothing but Hostile Mobs and Pebbles. \\n\\nPersonally I'd rather find Pebbles anywhere else...",
     "{image:atm:textures/questpics/undergarden/undergarden_barren.png width:200 height:100 align:center}",
   ],
+  "quest.4985F82E0D300C6D.quest_desc": [
+    "If you want to get home to the &2&lOverworld&r but can't find your original Portal, don't worry there is a way! \\n\\nWith 4 Depthrock, 4 &7Cloggrum Ingots&r, and a &aForgotten Nugget&r you can Craft the Crumbling Catalyst. \\n\\nThe Crumbling Catalyst works just like the normal Catalyst in activating a Portal. ",
+  ],
   "quest.4E3D548E5D8D7D26.quest_desc": [
-    "Forgotten Fields are the Plains of the &2&lUndergarden&r. \n\nThey don't have Trees but they have plenty of Rocks, Flowers, and Mobs! \n\nThey do not spawn &7Forgottens&r though, yeah sorry to ruin your enthusiasm.",
+    "Forgotten Fields are the Plains of the &2&lUndergarden&r. \\n\\nThey don't have Trees but they have plenty of Rocks, Flowers, and Mobs! \\n\\nThey do not spawn &7Forgottens&r though, yeah sorry to ruin your enthusiasm.",
     "{image:atm:textures/questpics/undergarden/undergarden_field.png width:200 height:100 align:center}",
   ],
   "quest.0FA77C28A57E06F1.quest_desc": [
-    "Veiled Mushrooms can only be found in their Bog. \n\nThey have Brown Caps which if there is Air below it, it will spawn Mushroom Veils. Hence the name!",
+    "Veiled Mushrooms can only be found in their Bog. \\n\\nThey have Brown Caps which if there is Air below it, it will spawn Mushroom Veils. Hence the name!",
   ],
-  "task.2116DA966E4C7711.title": "Understanding Utheric Infections",
   "quest.4C7E006502E30C20.quest_desc": [
-    "This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\n\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\n\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode.",
+    "This Quest has been authored by &6AllTheMods Staff&r, or a &2Community contributor&r for use in AllTheMods Modpacks.\\n\\nAs all &6AllTheMods&r packs are licensed under &eAll Rights Reserved&r, this Quest is not allowed to be used in any public packs not released by &6AllTheMods Team&r without explicit permission.\\n\\nThis quest is intentionally hidden, if you're seeing this, you're in editing mode.",
   ],
   "quest.06D13E319C26C949.quest_desc": [
-    "The Blood Mushroom Bog is home to the giant Blood Mushrooms. \n\nBlood makes me uneasy so I think I'll keep this description short.",
+    "The Blood Mushroom Bog is home to the giant Blood Mushrooms. \\n\\nBlood makes me uneasy so I think I'll keep this description short.",
     "{image:atm:textures/questpics/undergarden/undergarden_blood.png width:200 height:100 align:center}",
   ],
   "quest.1FCF946B7BE3C0BD.quest_desc": [
-    "&cUtherium&r Tools are similar to Diamond Tools but the weapons are more effective to &cRot Mobs&r! \n\nYou use what they make to do more damage to them! There's probably a dozen of pop culture references I can make with that but I can't think of any...",
+    "&cUtherium&r Tools are similar to Diamond Tools but the weapons are more effective to &cRot Mobs&r! \\n\\nYou use what they make to do more damage to them! There's probably a dozen of pop culture references I can make with that but I can't think of any...",
   ],
   "task.4AA225E5056787B8.title": "AllRightsReserved",
+  "quest.75A66B81C1181F59.title": "Forgotten Vestige",
   "quest.5D229FA3A5F92954.title": "&4Muncher&r",
   "quest.36389696767EFB4E.title": "Barren Abyss",
   "quest.1054168AFD8520D4.title": "&aForgotten Guardian&r",
   "quest.278D34BBC13356DF.quest_desc": [
-    "A purple Bog! \n\nThese have Ink Mushrooms and Virulent Mix all over!",
+    "A purple Bog! \\n\\nThese have Ink Mushrooms and Virulent Mix all over!",
     "{image:atm:textures/questpics/undergarden/undergarden_ink.png width:200 height:100 align:center}",
   ],
   "quest.49EB9FB2133E3219.title": "Ancient Armor",
   "quest.71E1454990DEC451.title": "&bGwib&r",
   "quest.130577AD1A1A8222.quest_desc": [
-    "&7Cloggrum&r has stats a little worse than Iron Armor, but it pratically grows on Trees so I think that's fair. \n\nThe Boots also help with going through Scintling Goo!",
+    "&7Cloggrum&r has stats a little worse than Iron Armor, but it pratically grows on Trees so I think that's fair. \\n\\nThe Boots also help with going through Scintling Goo!",
   ],
   "quest.119242549BD21764.quest_desc": [
-    "&eBrutes&r spawn in a few Biomes and are Neutral. \n\nIf hit, all in the area will attack you. Similar to Wolves or Zombified Piglins. \n\nOn death they might drop their Tusks, which can act as a replacement for Bones!",
+    "&eBrutes&r spawn in a few Biomes and are Neutral. \\n\\nIf hit, all in the area will attack you. Similar to Wolves or Zombified Piglins. \\n\\nOn death they might drop their Tusks, which can act as a replacement for Bones!",
     "{image:atm:textures/questpics/undergarden/undergarden_brute.png width:100 height:100 align:center}",
   ],
   "quest.1E13D7CE5A9EFF74.quest_desc": [
-    "Frostfields are one of the cold Biomes in the &2&lUndergarden&r. You can tell it is cold by the massive icesicles, Powdered Snow, and Frozen Deepturf! \n\nAlso here instead of the usual Depthrock underground you will find Shiverstone. \n\nShiverstone acts more like Ice than real Stone. Well atleast when standing on it!",
+    "Frostfields are one of the cold Biomes in the &2&lUndergarden&r. You can tell it is cold by the massive icesicles, Powdered Snow, and Frozen Deepturf! \\n\\nAlso here instead of the usual Depthrock underground you will find Shiverstone. \\n\\nShiverstone acts more like Ice than real Stone. Well atleast when standing on it!",
     "{image:atm:textures/questpics/undergarden/undergarden_frosty.png width:200 height:100 align:center}",
   ],
   "quest.17C2C8F64B4AE6EE.title": "&2Dweller&r",
+  "quest.30ED5FF9DF7B34CF.quest_desc": [
+    "By either Looting a Denizen Camp or Crafting this, we can use the Mysterious Totem! \\n\\nUhhh... how do we use it? \\n\\nSimply Place it down and every couple of Seconds it will give you &bPurity&r for 10 Seconds. \\n\\n&bPurity&r will cleanse you from the &cRot&r.",
+  ],
+  "quest.30D6924003C6E273.quest_desc": [
+    "&7Denizen&r Camps can be found within the Depths. You'll need to mine below Y Level 0 past the Dreadrock. \\n\\nDreadrock needs a &aForgotten Pickaxe&r to be Mined. That is the same Tier as the &6Allthemodium Pickaxe&r. \\n\\nHere a bunch of &7Denizens&r will spawn, plus Mysterious Totems and Chests! Rarely a Chest might spawn a Mysterious Mask, the same the &7Denizens&r wear. \\n\\nWearing a Mysterious Mask near &7Denizens&r is like wearing &eGold&r in front of Piglins. They will be Neutral unless someone is hit (or something is done to aggravate them).",
+  ],
   "quest.141681FE9E524FB0.quest_desc": [
-    "&7Forgottens&r are warriors that spawn within the Catacomb Structure. \n\nThey wear Ancient Armor and hold Cloggrum Tools, all which can be dropped upon death. \n\nThey will also target and kill &cRot Mobs&r.",
+    "&7Forgottens&r are warriors that spawn within the Catacomb Structure. \\n\\nThey wear Ancient Armor and hold Cloggrum Tools, all which can be dropped upon death. \\n\\nThey will also target and kill &cRot Mobs&r.",
     "{image:atm:textures/questpics/undergarden/undergarden_forgotten.png width:100 height:200 align:center}",
   ],
   "quest.43FD4AEBB9548E57.title": "Smogstem Forest",
   "quest.67A2347534269528.quest_desc": [
-    "&9Sploogies&r can rarely spawn but when they do they are destined to annoy you. \n\nThey will shoot spit at you (and make disgusting sucking noises) but if you hit them they will run away; similar to a baby Piglin. \n\nThey only drop Depthrock Pebbles on death.",
+    "&9Sploogies&r can rarely spawn but when they do they are destined to annoy you. \\n\\nThey will shoot spit at you (and make disgusting sucking noises) but if you hit them they will run away; similar to a baby Piglin. \\n\\nThey only drop Depthrock Pebbles on death.",
     "{image:atm:textures/questpics/undergarden/undergarden_sploogie.png width:125 height:100 align:center}",
   ],
   "quest.1054168AFD8520D4.quest_desc": [
-    "The &aForgotten Guardian&r is a massive Golem made of &aForgotten Ingots&r. \n\nIt'll target the Player and will do whatever needed to kill them. \n\nThey have 80 Hearts and if you can kill them they will drop &aForgotten Nuggets&r.",
+    "The &aForgotten Guardian&r is a massive Golem made of &aForgotten Ingots&r. \\n\\nIt'll target the Player and will do whatever needed to kill them. \\n\\nThey have 80 Hearts and if you can kill them they will drop &aForgotten Nuggets&r.",
     "{image:atm:textures/questpics/undergarden/undergarden_guardian.png width:100 height:200 align:center}",
   ],
+  "quest.2A2041098C069772.quest_desc": [
+    "&7Denizens&r Spawn in the Depths, which are below Y Level 0. You'll need a &aForgotten Pickaxe&r or similar Tier to Mine down there. \\n\\n&7Denizens&r look strangely and grossly human, they wear Mysterious Masks, and will hold either a Spear or Wooden Axe. \\n\\n&7Denizens&r come in short and round size and tall and skinny size. But all of them have 10 Hearts. \\n\\nThey don't have any Drops besides maybe their Weapon.",
+    "{image:atm:textures/questpics/undergarden/undergarden_denizens.png width:100 height:200 align:center}",
+  ],
+  "quest.6E7C8537D8A28833.title": "Depths",
+  "quest.257893DD23BF5017.title": "&3Rogdorium",
   "quest.4C5CFA45D9B4F6D3.quest_desc": [
     "Indigo Mushrooms are apparently bestfriends with Smogstem and will spawn mainly with them! ",
   ],
   "quest.15A8F04BC10E619E.quest_desc": [
-    "Some people hate exploring many different Biomes to get all the different Tree Saplings. \n\nClearly the &2&lUndergarden&r Dev did, so he put most of them in the Dense Forest!",
+    "Some people hate exploring many different Biomes to get all the different Tree Saplings. \\n\\nClearly the &2&lUndergarden&r Dev did, so he put most of them in the Dense Forest!",
     "{image:atm:textures/questpics/undergarden/undergarden_dense.png width:200 height:100 align:center}",
   ],
   "quest.7617737FC179EA1A.quest_desc": [
-    "&bFroststeel&r Armor is slightly worse than Diamond Armor but it also gives big Knockback Resistance. \n\nIt also gives Speed debuff though, looks like we ain't moving much!",
+    "&bFroststeel&r Armor is slightly worse than Diamond Armor but it also gives big Knockback Resistance. \\n\\nIt also gives Speed debuff though, looks like we ain't moving much!",
   ],
   "quest.4F5A2E2A5C7F4837.quest_desc": [
-    "&aForgotten Ingots&r need to be obtained through the Catacombs; whether it be looting the Chests or killing the &aForgotten Guardian&r. \n\nYou'll also need a Smithing Template which is found in Catacomb Chests.",
+    "&aForgotten Ingots&r need to be obtained through the Catacombs; whether it be looting the Chests or killing the &aForgotten Guardian&r. \\n\\nYou'll also need a Smithing Template which is found in Catacomb Chests.",
   ],
   "quest.4D836B9D9E3B898F.quest_desc": [
-    "&2Stoneborns&r are the perfect mix of Villagers and Iron Golems. \n\nYou can trade with them by Right Clicking them. \n\nAnd they will fight off Hostile Mobs (or Players who hit them).",
+    "&aStoneborns&r are the perfect mix of Villagers and Iron Golems. \\n\\nYou can trade with them by Right Clicking them. \\n\\nAnd they will fight off Hostile Mobs (or Players who hit them).",
     "{image:atm:textures/questpics/undergarden/undergarden_stoneborn.png width:100 height:150 align:center}",
   ],
   "quest.0D91A6B36BD2F526.title": "Ultimate Weapon!",
   "quest.17C2C8F64B4AE6EE.quest_desc": [
-    "&2Dwellers&r are the Cows of &2&lUndergarden&r. \nThey are Passive and will drop Leather and Dweller Meat on death. \n\nThank God they can't be milked, I don't want any milk these &2Dwellers&r make.",
+    "&2Dwellers&r are the Cows of &2&lUndergarden&r. \\n\\nThey are Passive and will drop Leather and Dweller Meat on death. \\n\\nThank God they can't be milked, I don't want any milk these &2Dwellers&r make.",
     "{image:atm:textures/questpics/undergarden/undergarden_dweller.png width:100 height:100 align:center}",
   ],
   "quest.1E81B903137BB62A.title": "&7Cloggrum&r Weapons",
   "quest.24D38DA8E86DD897.title": "&cRotling&r",
   "quest.380D3212D1CBA593.quest_desc": [
-    "The medium sized &cRot Mob&r, the &cRotwalker&r. \n\nThey have 20 Hearts. \n\nLike all &cRot Mobs&r they will target &2Stoneborns&r and &7Forgottens&r and will drop &cUtheric Shards&r.",
+    "The medium sized &cRot Mob&r, the &cRotwalker&r. \\n\\nThey have 20 Hearts. \\n\\nLike all &cRot Mobs&r they will target &2Stoneborns&r and &7Forgottens&r and will drop &cUtheric Shards&r.",
     "{image:atm:textures/questpics/undergarden/undergarden_rotwalker.png width:100 height:200 align:center}",
   ],
   "quest.43A1BC20BB054A14.quest_desc": [
-    "Glitterkelp grows in Ancient and Icy Seas. \n\nThey don't do much but Glow and can be crafted into Pie!",
+    "Glitterkelp grows in Ancient and Icy Seas. \\n\\nThey don't do much but Glow and can be crafted into Pie!",
   ],
   "quest.16A04B2FC3F0D902.quest_desc": [
-    "&7Cloggrum&r Tools act just like Iron Tools, these just look more like Mud than Iron does! \n\nThe Sword does more damage than an Iron Sword though.",
+    "&7Cloggrum&r Tools act just like Iron Tools, these just look more like Mud than Iron does! \\n\\nThe Sword does more damage than an Iron Sword though.",
+  ],
+  "quest.19862DBCE9305DE3.quest_desc": [
+    "The &3Javelin&r, the &7Denizen's&r weapon of choice... along with the Wooden Axe. \\n\\nYou'll need 2 Sticks and &3Rogdorium&r to Craft it. \\n\\nIt has the same Damage as a &bDiamond Sword&r, plus longer Reach! \\n\\nIt can also be thrown like a Trident.",
   ],
   "quest.2E596B5A4EA2ABF4.title": "&3S'Mog&r",
 }


### PR DESCRIPTION
- Fixed Missing Patchouli Guidebooks across all chapters (except Allthemodium, as I wanted to avoid a conflict with #333)
- Fixed the Iron Furnaces chapter
- Fixed the Quantum Bridge Card quest and properly hid all MEGA Cells related quests
- Nerfed Spawner Runes' XP Reward in Apothic Spawners (it was way more overtuned than I intended)
- Removed Extended Inscriber from a certain Smart Filter in Extended & Advanced AE
- Fixed Oritech Quests
- Ported Undergarden, Pylons, and Occultism quest changes from https://github.com/AllTheMods/ATM-10/pull/4219, with some differences
- Fixed an error in the Tome of Extraction's quest in Apothic Enchanting.