### PR TITLE
Fix Railcraft steel tools being uncraftable without Mekanism Tools

### DIFF
--- a/kubejs/server_scripts/unification/tools.js
+++ b/kubejs/server_scripts/unification/tools.js
@@ -3,24 +3,24 @@
 
 ServerEvents.recipes((allthemods) => {
   // Tools
-  allthemods.remove({ id: "mekanismtools:steel/tools/sword" })
-  allthemods.remove({ id: "railcraft:steel_sword" })
-  allthemods.remove({ id: "immersiveengineering:crafting/sword_steel" })
-  allthemods.remove({ id: "mekanismtools:steel/tools/pickaxe" })
-  allthemods.remove({ id: "railcraft:steel_pickaxe" })
-  allthemods.remove({ id: "immersiveengineering:crafting/pickaxe_steel" })
-  allthemods.remove({ id: "mekanismtools:steel/tools/axe" })
-  allthemods.remove({ id: "railcraft:steel_axe" })
-  allthemods.remove({ id: "immersiveengineering:crafting/axe_steel" })
-  allthemods.remove({ id: "mekanismtools:steel/tools/shovel" })
-  allthemods.remove({ id: "railcraft:steel_shovel" })
-  allthemods.remove({ id: "immersiveengineering:crafting/shovel_steel" })
-  allthemods.remove({ id: "mekanismtools:steel/tools/hoe" })
-  allthemods.remove({ id: "railcraft:steel_hoe" })
-  allthemods.remove({ id: "immersiveengineering:crafting/hoe_steel" })
-  allthemods.remove({ id: "mekanismtools:steel/tools/paxel" })
-
   if (Platform.isLoaded("mekanismtools")) {
+    allthemods.remove({ id: "mekanismtools:steel/tools/sword" })
+    allthemods.remove({ id: "railcraft:steel_sword" })
+    allthemods.remove({ id: "immersiveengineering:crafting/sword_steel" })
+    allthemods.remove({ id: "mekanismtools:steel/tools/pickaxe" })
+    allthemods.remove({ id: "railcraft:steel_pickaxe" })
+    allthemods.remove({ id: "immersiveengineering:crafting/pickaxe_steel" })
+    allthemods.remove({ id: "mekanismtools:steel/tools/axe" })
+    allthemods.remove({ id: "railcraft:steel_axe" })
+    allthemods.remove({ id: "immersiveengineering:crafting/axe_steel" })
+    allthemods.remove({ id: "mekanismtools:steel/tools/shovel" })
+    allthemods.remove({ id: "railcraft:steel_shovel" })
+    allthemods.remove({ id: "immersiveengineering:crafting/shovel_steel" })
+    allthemods.remove({ id: "mekanismtools:steel/tools/hoe" })
+    allthemods.remove({ id: "railcraft:steel_hoe" })
+    allthemods.remove({ id: "immersiveengineering:crafting/hoe_steel" })
+    allthemods.remove({ id: "mekanismtools:steel/tools/paxel" })
+
     allthemods
       .shaped("mekanismtools:steel_sword", [" S ", " S ", " R "], {
         S: "#c:ingots/steel",
@@ -62,14 +62,16 @@ ServerEvents.recipes((allthemods) => {
   }
 
   // Armor
-  allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_helmet" })
-  allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_chestplate" })
-  allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_leggings" })
-  allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_boots" })
-  allthemods.remove({ id: "railcraft:steel_helmet" })
-  allthemods.remove({ id: "railcraft:steel_chestplate" })
-  allthemods.remove({ id: "railcraft:steel_leggings" })
-  allthemods.remove({ id: "railcraft:steel_boots" })
+  if (Platform.isLoaded("mekanismtools")) {
+    allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_helmet" })
+    allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_chestplate" })
+    allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_leggings" })
+    allthemods.remove({ id: "immersiveengineering:crafting/armor_steel_boots" })
+    allthemods.remove({ id: "railcraft:steel_helmet" })
+    allthemods.remove({ id: "railcraft:steel_chestplate" })
+    allthemods.remove({ id: "railcraft:steel_leggings" })
+    allthemods.remove({ id: "railcraft:steel_boots" })
+  }
 
   // Shields
   allthemods.remove({ id: "the_bumblezone:honey_crystal_shield" })


### PR DESCRIPTION
### Problem

`kubejs/server_scripts/unification/tools.js` removes the Railcraft and Immersive Engineering steel tool and armor recipes unconditionally, but the replacement recipes those removals exist to make room for are guarded behind `Platform.isLoaded("mekanismtools")`.

Mekanism Tools is not in the 26.1.2 modlist, so the removals fire and nothing replaces them. `railcraft:steel_sword`, `steel_pickaxe`, `steel_axe`, `steel_shovel`, `steel_hoe` and the four Railcraft steel armor pieces currently have no recipe in the pack at all.

### Why it matters

The Advanced Item Loader and Advanced Item Unloader consume a steel shovel. That is exactly why `kubejs/server_scripts/tweaks/recipes.js` already carries

```js
if (Platform.isLoaded("railcraft") && Platform.isLoaded("mekanismtools")) {
  allthemods.replaceInput({ mod: "railcraft" }, "railcraft:steel_shovel", "mekanismtools:steel_shovel")
}
```

which is correctly guarded, so it never fires either. The Railcraft recipe therefore still asks for `railcraft:steel_shovel`, which is no longer obtainable.

Both **Advanced Item Loader** (`104049993CC62E7F`) and **Advanced Item Unloader** (`53594EBA9F7BA840`) are non-optional quests in the Railcraft chapter, so the chapter cannot currently be completed.

### Fix

Guard the removals with the same condition as the additions, so a duplicate is only removed when its unified replacement actually exists. No recipes are added or changed; the only behaviour difference is that the removals no longer run when Mekanism Tools is absent. When Mekanism Tools returns, unification resumes exactly as before.

The `mekanismtools:*` ids are unaffected either way, since `remove({ id })` on a recipe that is not present is a no-op — which is why this failed silently with nothing in the log.

### Note / possible follow-up

`kubejs/client_scripts/RecipeViewer.js` (lines 113–121) also hides these items from the recipe viewer unconditionally, so they will be craftable but still not visible in JEI. I left that out to keep this change to a single concern, but happy to add a matching guard if you'd prefer it in the same PR.

`kubejs/server_scripts/unification/gears.js` has the same shape — all twelve `railcraft:*_gear` recipes are removed unguarded, with Modern Industrialization as the intended replacement — but I have not verified whether anything installed still needs those, so it is not touched here.
